### PR TITLE
Fix to load tags correctly when the image files have been changed in the same directory.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,6 +294,21 @@ function openPath(pathName, isDir) {
 
             if (videotagging.imagelist.length){
               videotagging.imagelist = videotagging.imagelist.map((filepath) => {return path.join(pathName,filepath)});
+              if (config && config.framesByImagesName){
+                var frames = {};
+                for (var k in config.framesByImagesName){
+                  if (config.framesByImagesName.hasOwnProperty(k)) {
+                    var fullFilepath = path.join(pathName, k);
+                    var imgIndex = videotagging.imagelist.indexOf(fullFilepath);
+                    if (imgIndex > -1){
+                      frames[imgIndex] = config.framesByImagesName[k];
+                    }
+                  }
+                }
+                if (Object.keys(frames).length > 0){
+                  videotagging.inputframes = frames;
+                }
+              }
               videotagging.src = pathName; 
               //track visited frames
               $("#video-tagging").off("stepFwdClicked-AfterStep", updateVisitedFrames);
@@ -365,6 +380,17 @@ function save() {
       "visitedFrames": Array.from(visitedFrames),
       "tag_colors" : videotagging.optionalTags.colors,
     };
+    //for image directory
+    if (videotagging.imagelist){
+      var imgFramesByName = {};
+      Object.keys(videotagging.frames).forEach( i => {
+        if (!isNaN(Number(i))){
+          var imgFilename = path.basename(videotagging.imagelist[Number(i)]);
+          imgFramesByName[imgFilename] = videotagging.frames[i];
+        }
+      });
+      saveObject.framesByImagesName = imgFramesByName;
+    }
     //if nothing changed don't save
     if (saveState === JSON.stringify(saveObject) ) {
       return;


### PR DESCRIPTION
When the image files have been changed in the same directory, the saved tag will be loaded incorrectly because it is based the index of images in the directory ("videotagging.imagelist"). I have made the change that the array "videotagging.frames" will be transformed into a new array with the image filename as the key and save to a new property "framesByImagesName" in save file.