### PR TITLE
Update video-tagging.html

### DIFF
--- a/src/public/js/video-tagging/video-tagging.html
+++ b/src/public/js/video-tagging/video-tagging.html
@@ -493,7 +493,7 @@
 
             secondaryTags = [];
             for (var i = 1; i < tags.length; i++) {
-                let c = this.optionalTags.colors[this.inputtagsarray.indexOf(tags[i])];
+                let color = this.optionalTags.colors[Math.max(0, this.inputtagsarray.indexOf(tags[0]))];
                 let t = new this.btools.Tag(tags[i], this.btools.Tag.getHueFromColor(c) * 360);
                 secondaryTags.push(t)
             }                


### PR DESCRIPTION
handle exception. when tags that doesn't not exist in the optionalTags array, the app will not shows and boxes.