### PR TITLE
Feature/region selection improvements

### DIFF
--- a/src/public/js/video-tagging/css/regiontool.css
+++ b/src/public/js/video-tagging/css/regiontool.css
@@ -7,9 +7,9 @@
         //.tagStyle [n]
 --> .dragLayer
     --> .dragRectStyle
---> .ancorsLayer
-    --> .ancorStyle [4]
-        .ancorStyle.ghost
+--> .anchorsLayer
+    --> .anchorStyle [4]
+        .anchorStyle.ghost
 --> .menuLayer
     --> .menuRectStyle
 */
@@ -79,11 +79,11 @@
     fill:rgb(7, 189, 143);
 }
 
-.regionStyle:hover .ancorStyle {
+.regionStyle:hover .anchorStyle {
     stroke: #fff;
 }
 
-.regionStyle.selected .ancorStyle {
+.regionStyle.selected .anchorStyle {
     stroke: rgb(7, 189, 143);
 }
 

--- a/src/public/js/video-tagging/js/canvastools.js
+++ b/src/public/js/video-tagging/js/canvastools.js
@@ -1035,7 +1035,7 @@ define("regiontool", ["require", "exports", "basetool", "./public/js/video-taggi
                     let sr = this.regions;
                     this.deleteAllRegions();
                     for(var i = 0; i < sr.length; i++) {
-                        this.drawRegion(sr[i].x, sr[i].y, sr[i].rect, sr[i].ID, sr[i].tagsDescriptor);
+                        this.drawRegion(sr[i].x, sr[i].y, sr[i].rect, sr[i].ID, sr[i].tags.tags);
                         if(sr[i].isSelected) {
                             this.selectRegionById(sr[i].ID);
                         }
@@ -1045,7 +1045,7 @@ define("regiontool", ["require", "exports", "basetool", "./public/js/video-taggi
                 redrawRegion(region) {
                     let newRegion = region;
                     this.deleteRegion(region);
-                    this.drawRegion(newRegion.x, newRegion.y, newRegion.rect, newRegion.ID, newRegion.tagsDescriptor);
+                    this.drawRegion(newRegion.x, newRegion.y, newRegion.rect, newRegion.ID, newRegion.tags.tags);
                     if(region.isSelected) {
                         this.selectRegionById(region.ID);
                     }
@@ -1057,9 +1057,13 @@ define("regiontool", ["require", "exports", "basetool", "./public/js/video-taggi
                     region.area = rect.height * rect.width;
                     region.move(new base.Point2D(x, y));
                     region.onChange = this.onRegionUpdate.bind(this);
-                    region.tags.updateTags(tagsDescriptor);
+                    region.tags.updateTags(region.tags.tags);
                     this.regionManagerLayer.add(region.regionGroup);
                     this.regions.push(region);
+                    // Need to do a check for invalid stacking from user generated or older saved json
+                    if(this.regions.length > 1 && region.area > this.regions[this.regions.length - 2]) {
+                        this.redrawAllRegions();
+                    }
                     this.sortRegionsByArea();
                     this.menu.showOnRegion(region);  
                 }
@@ -1070,7 +1074,6 @@ define("regiontool", ["require", "exports", "basetool", "./public/js/video-taggi
                     let w = Math.abs(pointA.x - pointB.x);
                     let h = Math.abs(pointA.y - pointB.y);
                     this.drawRegion(x, y, new base.Rect(w,h), id, tagsDescriptor);
-                    this.redrawAllRegions();
                     this.unselectRegions();
                     this.selectRegionById(id);
                     //this.updateTagsById(id);
@@ -1279,7 +1282,6 @@ define("regiontool", ["require", "exports", "basetool", "./public/js/video-taggi
                         r.move(new base.Point2D(r.x * tw, r.y * th));
                         r.resize(r.rect.width * tw, r.rect.height * th);
                     }
-                    this.redrawAllRegions();
                 }
                 onManipulationBegin_local(region) {
                     this.onManipulationBegin();

--- a/src/public/js/video-tagging/js/canvastools.js
+++ b/src/public/js/video-tagging/js/canvastools.js
@@ -1630,7 +1630,6 @@ define("selectiontool", ["require", "exports", "basetool", "./public/js/video-ta
                     }
                     if (e.ctrlKey && !this.capturingState) {
                             this.twoPointsMode = true;
-                            console.log("TwoPointsMode " + this.twoPointsMode);
                     }
                 }
                 onKeyUp(e) {
@@ -1639,7 +1638,6 @@ define("selectiontool", ["require", "exports", "basetool", "./public/js/video-ta
                     }
                     if (!e.ctrlKey && this.twoPointsMode && !this.exclusiveCapturingState) {
                         this.twoPointsMode = false;
-                        console.log("TwoPointsMode exits " + this.twoPointsMode);
                         this.capturingState = false;
                         this.moveCross(this.crossA, this.crossB);
                         this.hideAll([this.crossB, this.selectionBox, this.overlay]);
@@ -1649,7 +1647,6 @@ define("selectiontool", ["require", "exports", "basetool", "./public/js/video-ta
                     if(e.ctrlKey && e.keyCode == 78 && !this.exclusiveCapturingState) {
                         this.enableExclusiveMode();
                         this.twoPointsMode = false;
-                        console.log("TwoPointsMode in exclusive mode " + this.twoPointsMode);
                     } 
                     //Escape to exit exclusive mode
                     if(e.keyCode == 27) {

--- a/src/public/js/video-tagging/video-tagging.html
+++ b/src/public/js/video-tagging/video-tagging.html
@@ -200,6 +200,13 @@
                 self.btools = modules[2].CanvasTools.Base;
 
                 var regionsManager;
+                
+
+                regionsManager = new self.rtools.RegionsManager(self.selectionZone, 
+                    function() { },
+                    function() { })
+                ;
+
                 self.areaSelector = new self.stools.AreaSelector(self.selectionZone, 
                     function(){
                         self.selectionZone.style.zIndex = 300;
@@ -210,14 +217,12 @@
                     }
                 );
 
-                regionsManager = new self.rtools.RegionsManager(self.selectionZone, 
-                    function() {
-                        self.areaSelector.disable();
-                    },
-                    function() {
-                        self.areaSelector.enable();
-                    })
-                ;
+                regionsManager.onManipulationEnd = function() {
+                    self.areaSelector.enable();
+                };
+                regionsManager.onManipulationBegin = function() {
+                    self.areaSelector.disable();
+                };
 
                 regionsManager.onRegionSelected = function(id, multiselection) {                    
                     self.selectRegion(id, multiselection);
@@ -724,7 +729,11 @@
                 
                 this.registerRegion(x1, y1, x2, y2, region.UID, region.tags); ; //add frame                  
             }
+            //Redraws all regions to ensure proper z-order stacking
+            this.regionsManager.redrawAllRegions();
         }
+        //Clears areaSelector state when moving across frames
+        this.regionsManager.onManipulationEnd();
     },
     
     /**


### PR DESCRIPTION
Makes several improvements to tag regions:

1) Fixes bug when mouse is on a region and next frame is called, resulting in a loss of state. It makes the user unable to create new tags
2) Fixes z-ordering of tags so smallest area always is on top.  Eliminates the issue of drawing large regions that block the user's ability to edit regions underneath it.
3) Added "exclusive add region mode" - CTRL+N blocks the frame UI allowing a user to create a region on top of existing regions.