### PR TITLE
Fix video export bug

### DIFF
--- a/src/lib/videotagging_extensions/detection.js
+++ b/src/lib/videotagging_extensions/detection.js
@@ -43,7 +43,7 @@ function Detection(videotagging, visitedFrames) {
             }
 
             function iterateFrames() {
-                var frameId = self.videotagging.getCurrentFrame();
+                var frameId = self.videotagging.getCurrentFrameNumber();
                 var lastFrame = isLastFrame(frameId);
 
                 if (lastFrame) {


### PR DESCRIPTION
Fix export bug where detection.js was referencing getCurrentFrame function which doesn't exist.