### PR TITLE
Add shortcut to move frames

### DIFF
--- a/src/public/html/help-configuration.html
+++ b/src/public/html/help-configuration.html
@@ -25,6 +25,8 @@
             <li><strong>Open Video:</strong> Ctrl + O</li>
             <li><strong>Open Image Directory:</strong> Ctrl + I</li>
             <li><strong>Save Tags:</strong> Ctrl + S</li>
+            <li><strong>Next Frame:</strong>Right Arrow or E</li>
+            <li><strong>Previous Frame:</strong>Left Arrow or Q</li>
             <li><strong>Toggle Play/Pause:</strong> Space</li>
             <li><strong>Toggle Tracking:</strong> Ctrl + T</li>
             <li><strong>Toggle Exclusive Add Mode:</strong> Crtl + N</li>

--- a/src/public/js/video-tagging/video-tagging.html
+++ b/src/public/js/video-tagging/video-tagging.html
@@ -446,6 +446,7 @@
                 }            
                 break;
             case 68:// d for duplicate
+                if(e.ctrlKey) break;
                 let frameId = this.getCurrentFrameId();
                 if(this.imagelist){
                     frameId = this.imageIndex
@@ -457,6 +458,16 @@
                 break;
             case 32:// space to toggle play/pause
                 this.playPauseClicked();
+                break;
+            case 81:// q to go back a frame
+                if (!e.ctrlKey) {
+                    this.stepBwdClicked();
+                }
+                break;
+            case 69:// e to go forward a frame
+                if (!e.ctrlKey) {
+                    this.stepFwdClicked();
+                }
                 break;
             default: return; // exit this handler for other keys
             }


### PR DESCRIPTION
Add shortcut to be able to move between frames using Q and E keys. Used to speed up tagging flow. 

Resolves #326