### PR TITLE
Add the version number to the help menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,8 @@ const BrowserWindow = electron.BrowserWindow;
 const windowStateKeeper = require('electron-window-state');
 const path = require('path');
 const url = require('url');
+// To access the version defined in package.json
+require('pkginfo')(module, 'version');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -262,7 +264,7 @@ function createWindow () {
           click () { mainWindow.webContents.send('help');}
         },
         {
-          label: 'Version: ' + process.env.npm_package_version
+          label: 'Version: ' + module.exports.version
         }
       ]
     }	    


### PR DESCRIPTION
PR related to #347, #298, #297, #296 to supply information about the currently used VOTT version. This way, the version number will simply be displayed as entry inside the "Help" menu. It may be a small stepp to add it to the titlebar or maybe as color coded information as mentioned in those issues.

Note, this is the version as defined in the package.json.
https://github.com/Microsoft/VoTT/blob/ec6057c4c95780f7547d5c55245c6f48b396e29c/package.json#L3

This works when starting the app with npm start, however may fail with a build version (not tested).

close #347 