### PR TITLE
Display a scrollbar for the tags list when not all tags are visible

### DIFF
--- a/src/public/js/video-tagging/css/video-tagging.css
+++ b/src/public/js/video-tagging/css/video-tagging.css
@@ -288,6 +288,8 @@ z-index: 10;
   float: left;
   width: 85%;
   margin: 1em 0 0 1.5em;
+  overflow-y: auto;
+  height: 100%;
 }
 
 .labelControls {


### PR DESCRIPTION
If more tags are added to the tag list than can be displayed, they are simply truncated and are no longer visible. By using the css attribute _overflow-y: auto_, a scrollbar is displayed as soon as the elements within the div exceed the visible area. This also applies if the app window size is reduced and the tags would become unvisible.

closes #320.