### PR TITLE
[AB#16330] Set up codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,7 @@
 # cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
 
 comment:  # enable pull request comment
+  layout: "reach, diff, flags, files"
   behavior: new # delete old report and post new one
 coverage:
   range: 70..100

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,7 @@
-comment: on  # enable pull request comment
+# Validate changes
+# cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
+
+comment:  # enable pull request comment
   behavior: new # delete old report and post new one
 coverage:
   range: 70..100

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+comment: on  # enable pull request comment
+  behavior: new # delete old report and post new one
+coverage:
+  range: 70..100
+  round: down # round down to the precision point
+  precision: 2
+  status:
+    project: # compare project coverage against the base of pr
+      default:
+        target: 75%  # min coverage ratio to be considered a success
+        threshold: null  # allow coverage to drop by X%
+        base: auto   

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,7 @@
 # Validate changes
 # cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
 
-comment:  # enable pull request comment
-  layout: "reach, diff, flags, files"
-  behavior: new # delete old report and post new one
+comment:  on # enable pull request comment
 coverage:
   range: 70..100
   round: down # round down to the precision point

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# dev
+secrets.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VoTT (Visual Object Tagging Tool)
 
-[![Build Status](https://dev.azure.com/msft-vott/VoTT/_apis/build/status/VoTT-CI?branchName=v2)](https://dev.azure.com/msft-vott/VoTT/_build/latest?definitionId=6?branchName=v2)
+[![Build Status](https://dev.azure.com/msft-vott/VoTT/_apis/build/status/VoTT-CI?branchName=v2)](https://dev.azure.com/msft-vott/VoTT/_build/latest?definitionId=6?branchName=v2) [![Code Coverage](https://codecov.io/gh/Microsoft/VoTT/branch/v2/graph/badge.svg)](https://codecov.io/gh/Microsoft/VoTT)
 
 The `v2` branch is a complete reboot of the original VoTT, and currently don't share git histories. The purpose of `v2` is to create a more extensible version of the original application while leveraging more recent frameworks such as React/Redux.
 

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -28,3 +28,7 @@ steps:
     npm run compile
     npm run test:ci # don't watch and just run all the tests
   displayName: 'Run tests'
+
+- bash: |
+    bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
+  displayName: 'Upload coverage report'

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -30,5 +30,6 @@ steps:
   displayName: 'Run tests and coverage'
 
 - bash: |
+    # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
   displayName: 'Upload coverage report'

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -26,8 +26,8 @@ steps:
 
     npm ci  # do a clean install
     npm run compile
-    npm run test:ci # don't watch and just run all the tests
-  displayName: 'Run tests'
+    npm run test:coverage # run tests and coverage
+  displayName: 'Run tests and coverage'
 
 - bash: |
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,8 @@
 comment: on  # enable pull request comment
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: null
+        base: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 comment: on  # enable pull request comment
+
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: on  # enable pull request comment

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-comment: on  # enable pull request comment
-
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: null
-        base: auto

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "test": "react-scripts test --env=jsdom --silent",
         "test:ci": "cross-env CI=true npm run test",
         "test:coverage": "npm run test -- --coverage",
-        "coverage": "react-scripts test --env=jsdom --coverage --silent",
         "eject": "react-scripts eject",
         "electron": "webpack --config ./config/webpack.dev.js && electron .",
         "electron:prod": "webpack -p --config ./config/webpack.prod.js",


### PR DESCRIPTION
1. Modify linux agent test run to upload coverage report to codecov.
1. Enable pr comment so codecov can post back report to PR.
1. Enable commit status so it will block if coverage goes down.