### PR TITLE
set explicit target for patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,4 +11,7 @@ coverage:
       default:
         target: 75%  # min coverage ratio to be considered a success
         threshold: null  # allow coverage to drop by X%
-        base: auto   
+        base: auto
+    patch:  # provides an indication on how well the pull request is tested
+      default:
+        target: 70% # min coverage ratio to be considered a success

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # dev
 secrets.sh
+
+# ide
+.idea


### PR DESCRIPTION
otherwise it will use the current coverage of base branch