### PR TITLE
Adding default export filter and updating tests - AB#16446

### DIFF
--- a/src/providers/export/exportProviderFactory.test.ts
+++ b/src/providers/export/exportProviderFactory.test.ts
@@ -43,6 +43,25 @@ describe("Export Provider Factory", () => {
         expect(provider).toBeInstanceOf(TestExportProvider);
     });
 
+    it("ensures default is correct", () => {
+        expect(Object.keys(ExportProviderFactory.providers).length).toEqual(1);
+        ExportProviderFactory.register({
+            name: "testProvider2",
+            displayName: "Second Test Provider",
+            factory: (project) => new TestExportProvider(project),
+        });
+        ExportProviderFactory.register({
+            name: "testProvider3",
+            displayName: "Third Test Provider",
+            factory: (project) => new TestExportProvider(project),
+        });
+        expect(Object.keys(ExportProviderFactory.providers).length).toEqual(3);
+        expect(ExportProviderFactory.defaultProvider).not.toBeNull();
+        expect(ExportProviderFactory.defaultProvider.name).toEqual("testProvider");
+        expect(ExportProviderFactory.defaultProvider.displayName).toEqual("Test Provider");
+
+    });
+
     it("throws error if provider is not found", () => {
         expect(() => ExportProviderFactory.create(
             "unknown",

--- a/src/providers/export/exportProviderFactory.ts
+++ b/src/providers/export/exportProviderFactory.ts
@@ -15,7 +15,7 @@ export interface IExportProviderRegistrationOptions {
  */
 export class ExportProviderFactory {
     public static get providers() {
-        return { ...ExportProviderFactory.providerRegistery };
+        return { ...ExportProviderFactory.providerRegistry };
     }
 
     public static get defaultProvider() {
@@ -36,7 +36,7 @@ export class ExportProviderFactory {
         if (ExportProviderFactory.defaultProviderOptions === null) {
             ExportProviderFactory.defaultProviderOptions = options;
         }
-        ExportProviderFactory.providerRegistery[options.name] = options;
+        ExportProviderFactory.providerRegistry[options.name] = options;
     }
 
     /**
@@ -49,7 +49,7 @@ export class ExportProviderFactory {
         Guard.emtpy(name);
         Guard.null(project);
 
-        const handler = ExportProviderFactory.providerRegistery[name];
+        const handler = ExportProviderFactory.providerRegistry[name];
         if (!handler) {
             throw new Error(`No export provider has been registered with name '${name}'`);
         }
@@ -65,6 +65,6 @@ export class ExportProviderFactory {
         );
     }
 
-    private static providerRegistery: { [id: string]: IExportProviderRegistrationOptions } = {};
+    private static providerRegistry: { [id: string]: IExportProviderRegistrationOptions } = {};
     private static defaultProviderOptions: IExportProviderRegistrationOptions = null;
 }

--- a/src/providers/export/exportProviderFactory.ts
+++ b/src/providers/export/exportProviderFactory.ts
@@ -18,6 +18,10 @@ export class ExportProviderFactory {
         return { ...ExportProviderFactory.providerRegistery };
     }
 
+    public static get defaultProvider() {
+        return ExportProviderFactory.defaultProviderOptions;
+    }
+
     /**
      * Registers a factory method for the specified export provider type
      * @param options - The options to use when registering an export provider
@@ -28,6 +32,10 @@ export class ExportProviderFactory {
         Guard.emtpy(options.displayName);
         Guard.null(options.factory);
 
+        // The first provider registered will be the default
+        if (ExportProviderFactory.defaultProviderOptions === null) {
+            ExportProviderFactory.defaultProviderOptions = options;
+        }
         ExportProviderFactory.providerRegistery[options.name] = options;
     }
 
@@ -58,4 +66,5 @@ export class ExportProviderFactory {
     }
 
     private static providerRegistery: { [id: string]: IExportProviderRegistrationOptions } = {};
+    private static defaultProviderOptions: IExportProviderRegistrationOptions = null;
 }

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -150,7 +150,7 @@ describe("Editor Page Component", () => {
             currentProject: project,
         });
         const props = MockFactory.editorPageProps();
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
 
         const editorPage = wrapper.find(EditorPage).childAt(0);
         const spy = jest.spyOn(editorPage.instance() as EditorPage, "onTagClicked");

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -19,7 +19,7 @@ describe("Editor Page Component", () => {
     let assetServiceMock: jest.Mocked<typeof AssetService> = null;
     let projectServiceMock: jest.Mocked<typeof ProjectService> = null;
 
-    function createCompoent(store, props: IEditorPageProps): ReactWrapper {
+    function createComponent(store, props: IEditorPageProps): ReactWrapper {
         return mount(
             <Provider store={store}>
                 <Router>
@@ -56,7 +56,7 @@ describe("Editor Page Component", () => {
         const props = MockFactory.editorPageProps(testProject.id);
         const loadProjectSpy = jest.spyOn(props.actions, "loadProject");
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         const editorPage = wrapper.find(EditorPage).childAt(0);
 
         expect(loadProjectSpy).not.toBeCalled();
@@ -82,7 +82,7 @@ describe("Editor Page Component", () => {
             return Promise.resolve(savedAssetMetadata);
         });
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         const editorPage = wrapper.find(EditorPage).childAt(0);
 
         const partialProject = {
@@ -128,7 +128,7 @@ describe("Editor Page Component", () => {
         const saveProjectSpy = jest.spyOn(props.actions, "saveProject");
 
         // create mock editor page
-        createCompoent(store, props);
+        createComponent(store, props);
 
         const partialProject = {
             id: testProject.id,

--- a/src/react/components/pages/export/exportForm.test.tsx
+++ b/src/react/components/pages/export/exportForm.test.tsx
@@ -93,7 +93,7 @@ describe("Export Form Component", () => {
         };
 
         const props: IExportFormProps = {
-            settings: defaultExportSettings,
+            settings: null,
             onSubmit: onSubmitHandler,
         };
 

--- a/src/react/components/pages/export/exportForm.test.tsx
+++ b/src/react/components/pages/export/exportForm.test.tsx
@@ -21,6 +21,9 @@ describe("Export Form Component", () => {
         Object.defineProperty(ExportProviderFactory, "providers", {
             get: jest.fn(() => exportProviderRegistrations),
         });
+        Object.defineProperty(ExportProviderFactory, "defaultProvider", {
+            get: jest.fn(() => exportProviderRegistrations[0]),
+        });
     });
 
     const onSubmitHandler = jest.fn();
@@ -28,12 +31,7 @@ describe("Export Form Component", () => {
     it("State is initialized without export settings", () => {
         const defaultExportType = "vottJson";
         const props: IExportFormProps = {
-            settings: {
-                providerType: "vottJson",
-                providerOptions: {
-                    assetState: ExportAssetState.Tagged,
-                },
-            },
+            settings: null,
             onSubmit: onSubmitHandler,
         };
 

--- a/src/react/components/pages/export/exportForm.tsx
+++ b/src/react/components/pages/export/exportForm.tsx
@@ -38,8 +38,7 @@ export default class ExportForm extends React.Component<IExportFormProps, IExpor
 
         this.state = {
             classNames: ["needs-validation"],
-            providerName: this.props.settings ?
-                this.props.settings.providerType : null,
+            providerName: this.props.settings ? this.props.settings.providerType : null,
             formSchema: { ...formSchema },
             uiSchema: { ...uiSchema },
             formData: this.props.settings,

--- a/src/react/components/pages/export/exportForm.tsx
+++ b/src/react/components/pages/export/exportForm.tsx
@@ -3,6 +3,7 @@ import _ from "lodash";
 import Form, { Widget, FormValidation, IChangeEvent, ISubmitEvent } from "react-jsonschema-form";
 import { addLocValues, strings } from "../../../../common/strings";
 import { IExportFormat } from "../../../../models/applicationState";
+import { ExportProviderFactory } from "../../../../providers/export/exportProviderFactory";
 import ExportProviderPicker from "../../common/exportProviderPicker/exportProviderPicker";
 import CustomFieldTemplate from "../../common/customField/customFieldTemplate";
 import ExternalPicker from "../../common/externalPicker/externalPicker";
@@ -37,7 +38,8 @@ export default class ExportForm extends React.Component<IExportFormProps, IExpor
 
         this.state = {
             classNames: ["needs-validation"],
-            providerName: this.props.settings ? this.props.settings.providerType : null,
+            providerName: this.props.settings ?
+                this.props.settings.providerType : null,
             formSchema: { ...formSchema },
             uiSchema: { ...uiSchema },
             formData: this.props.settings,
@@ -119,7 +121,9 @@ export default class ExportForm extends React.Component<IExportFormProps, IExpor
 
     private bindForm(exportFormat: IExportFormat, resetProviderOptions: boolean = false) {
 
-        const providerType = exportFormat ? exportFormat.providerType : null;
+        // If no provider type was specified on bind, pick the default provider
+        const providerType = (exportFormat && exportFormat.providerType) ?
+            exportFormat.providerType : ExportProviderFactory.defaultProvider.name;
         let newFormSchema: any = this.state.formSchema;
         let newUiSchema: any = this.state.uiSchema;
 
@@ -138,6 +142,7 @@ export default class ExportForm extends React.Component<IExportFormProps, IExpor
         if (resetProviderOptions) {
             formData.providerOptions = {};
         }
+        formData.providerType = providerType;
 
         this.setState({
             providerName: providerType,

--- a/src/react/components/pages/export/exportPage.test.tsx
+++ b/src/react/components/pages/export/exportPage.test.tsx
@@ -7,16 +7,19 @@ import ExportPage, { IExportPageProps } from "./exportPage";
 import { IApplicationState, IProject } from "../../../../models/applicationState";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
 import createReduxStore from "../../../../redux/store/store";
-import { ExportProviderFactory } from "../../../../providers/export/exportProviderFactory";
 import MockFactory from "../../../../common/mockFactory";
 
 jest.mock("../../../../services/projectService");
 import ProjectService from "../../../../services/projectService";
 
+jest.mock("../../../../providers/export/exportProviderFactory");
+import { ExportProviderFactory } from "../../../../providers/export/exportProviderFactory";
+
 describe("Export Page", () => {
+    const exportProviderRegistrations = MockFactory.createExportProviderRegistrations();
     let projectServiceMock: jest.Mocked<typeof ProjectService> = null;
 
-    function createCompoent(store, props: IExportPageProps): ReactWrapper {
+    function createComponent(store, props: IExportPageProps): ReactWrapper {
         return mount(
             <Provider store={store}>
                 <Router>
@@ -25,6 +28,15 @@ describe("Export Page", () => {
             </Provider>,
         );
     }
+
+    beforeAll(() => {
+        Object.defineProperty(ExportProviderFactory, "providers", {
+            get: jest.fn(() => exportProviderRegistrations),
+        });
+        Object.defineProperty(ExportProviderFactory, "defaultProvider", {
+            get: jest.fn(() => exportProviderRegistrations[0]),
+        });
+    });
 
     beforeEach(() => {
         projectServiceMock = ProjectService as jest.Mocked<typeof ProjectService>;
@@ -36,7 +48,7 @@ describe("Export Page", () => {
         const props = createProps(testProject.id);
         const loadProjectSpy = jest.spyOn(props.actions, "loadProject");
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         const exportPage = wrapper.find(ExportPage).childAt(0);
 
         expect(loadProjectSpy).not.toBeCalled();
@@ -49,7 +61,7 @@ describe("Export Page", () => {
         const props = createProps(testProject.id);
         const loadProjectSpy = jest.spyOn(props.actions, "loadProject");
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         const exportPage = wrapper.find(ExportPage).childAt(0);
 
         setImmediate(() => {
@@ -75,7 +87,7 @@ describe("Export Page", () => {
 
         projectServiceMock.prototype.save = jest.fn((project) => Promise.resolve(project));
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         wrapper.find("form").simulate("submit");
         wrapper.update();
 


### PR DESCRIPTION
- Adding default export filter if none is selected (currently first registered filter is set as default)
- Adding test for default export filter
- Fixing test verifying null settings appropriate uses default export
- Fixed a typo of "component" I saw that was super annoying me