### PR TITLE
Fixing bug introduced on default video settings

### DIFF
--- a/src/react/components/pages/projectSettings/projectForm.tsx
+++ b/src/react/components/pages/projectSettings/projectForm.tsx
@@ -87,7 +87,8 @@ export default class ProjectForm extends React.Component<IProjectFormProps, IPro
         if (this.props.project) {
             if (this.state.formData.videoSettings === null || this.state.formData.videoSettings === undefined) {
                 this.state.formData.videoSettings = {
-                    frameExtractionRate: this.state.formSchema.videoSettings.properties.frameExtractionRate.default,
+                    frameExtractionRate:
+                    this.state.formSchema.properties.videoSettings.properties.frameExtractionRate.default,
                 };
             }
        }

--- a/src/react/components/pages/projectSettings/projectForm.tsx
+++ b/src/react/components/pages/projectSettings/projectForm.tsx
@@ -83,16 +83,6 @@ export default class ProjectForm extends React.Component<IProjectFormProps, IPro
             },
         };
 
-        // Set the default video settings if they are not already set
-        if (this.props.project) {
-            if (this.state.formData.videoSettings === null || this.state.formData.videoSettings === undefined) {
-                this.state.formData.videoSettings = {
-                    frameExtractionRate:
-                    this.state.formSchema.properties.videoSettings.properties.frameExtractionRate.default,
-                };
-            }
-       }
-
         this.onFormSubmit = this.onFormSubmit.bind(this);
         this.onFormCancel = this.onFormCancel.bind(this);
         this.onFormValidate = this.onFormValidate.bind(this);


### PR DESCRIPTION
Somehow I missed a .properties in finding the default from the schema, will add another test to catch this, but opening PR for this since project settings are likely broken at moment.