### PR TITLE
Adding video player to editor page - AB#16699

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11029,7 +11029,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10248,6 +10248,11 @@
                 "lodash._reinterpolate": "~3.0.0"
             }
         },
+        "lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+        },
         "lodash.tonumber": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
@@ -13810,14 +13815,25 @@
             }
         },
         "react": {
-            "version": "16.6.3",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
-            "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+            "version": "16.7.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
+            "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
-                "scheduler": "^0.11.2"
+                "scheduler": "^0.12.0"
+            },
+            "dependencies": {
+                "scheduler": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
+                    "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "react-app-polyfill": {
@@ -14026,14 +14042,25 @@
             }
         },
         "react-dom": {
-            "version": "16.6.3",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
-            "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+            "version": "16.7.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
+            "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
-                "scheduler": "^0.11.2"
+                "scheduler": "^0.12.0"
+            },
+            "dependencies": {
+                "scheduler": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
+                    "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "react-error-overlay": {
@@ -15643,6 +15670,7 @@
             "version": "0.11.3",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
             "integrity": "sha1-tXabkM+LFGTz88/K/o4811VaLWs=",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -17930,6 +17958,17 @@
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
+            }
+        },
+        "video-react": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/video-react/-/video-react-0.13.2.tgz",
+            "integrity": "sha512-CbpwtNnGxJbfbyby7gIcUrKv4psLrmHuIFBFZ0hgQXU9sDs6aPeFGitQ0d4CoJ158KeMKvAkIeJGF5ku5x9j8A==",
+            "requires": {
+                "classnames": "^2.2.3",
+                "lodash.throttle": "^4.1.1",
+                "prop-types": "^15.5.8",
+                "redux": "^4.0.0"
             }
         },
         "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "deepmerge": "^2.2.1",
         "lodash": "^4.17.11",
         "md5.js": "^1.3.5",
-        "react": "^16.6.3",
-        "react-dom": "^16.6.3",
+        "react": "^16.7.0",
+        "react-dom": "^16.7.0",
         "react-keydown": "^1.9.7",
         "react-localization": "^1.0.13",
         "react-redux": "^5.1.1",
@@ -24,7 +24,8 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "rimraf": "^2.6.2",
-        "shortid": "^2.2.14"
+        "shortid": "^2.2.14",
+        "video-react": "^0.13.2"
     },
     "scripts": {
         "start": "nf start -p 3000",

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -1,7 +1,7 @@
 import shortid from "shortid";
 import {
     AssetState, AssetType, IAppError, IApplicationState, IAppSettings, IAsset, IAssetMetadata,
-    IConnection, IExportFormat, IProject, ITag, StorageType, IVideoSettings,
+    IConnection, IExportFormat, IProject, ITag, StorageType, IProjectVideoSettings,
 } from "../models/applicationState";
 import { ExportAssetState } from "../providers/export/exportProvider";
 import { IAssetProvider, IAssetProviderRegistrationOptions } from "../providers/storage/assetProviderFactory";
@@ -54,13 +54,39 @@ export default class MockFactory {
     }
 
     /**
+     * @name Create Video Test Asset
+     * @description Creates fake video IAsset
+     * @param name Name of asset
+     * @param assetState State of asset
+     */
+    public static createVideoTestAsset(name: string, assetState: AssetState = AssetState.NotVisited): IAsset {
+        return {
+            id: `videoasset-${name}`,
+            format: "mp4",
+            name: `Video Asset ${name}`,
+            path: `C:\\Desktop\\videoasset${name}.mp4`,
+            state: assetState,
+            type: AssetType.Video,
+            size: {
+                width: 800,
+                height: 600,
+            },
+        };
+    }
+
+    /**
      * Creates array of fake IAsset
      * @param count Number of assets to create
      */
     public static createTestAssets(count: number = 10): IAsset[] {
         const assets: IAsset[] = [];
-        for (let i = 1; i <= count; i++) {
-            assets.push(MockFactory.createTestAsset(i.toString()));
+        for (let i = 1; i <= count / 2; i++) {
+            assets.push(MockFactory.createVideoTestAsset(i.toString()));
+        }
+        if (count > 1) {
+            for (let i = 1; i <= count / 2; i++) {
+                assets.push(MockFactory.createTestAsset(i.toString()));
+            }
         }
 
         return assets;
@@ -112,9 +138,9 @@ export default class MockFactory {
     }
 
     /**
-     * Creates fake IVideoSettings with default values
+     * Creates fake IProjectVideoSettings with default values
      */
-    public static createVideoSettings(): IVideoSettings {
+    public static createVideoSettings(): IProjectVideoSettings {
         return { frameExtractionRate: 15 };
     }
 
@@ -539,11 +565,9 @@ export default class MockFactory {
      * Runs function that updates the UI, and flushes call stack
      * @param func - The function that updates the UI
      */
-    public static flushUi(func: () => void = null): Promise<void> {
+    public static flushUi(func: () => void): Promise<void> {
         return new Promise<void>((resolve) => {
-            if (func) {
-                func();
-            }
+            func();
             setImmediate(resolve);
         });
     }

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -565,9 +565,11 @@ export default class MockFactory {
      * Runs function that updates the UI, and flushes call stack
      * @param func - The function that updates the UI
      */
-    public static flushUi(func: () => void): Promise<void> {
+    public static flushUi(func: () => void = null): Promise<void> {
         return new Promise<void>((resolve) => {
-            func();
+            if (func) {
+                func();
+            }
             setImmediate(resolve);
         });
     }

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -62,7 +62,7 @@ export interface IProject {
     sourceConnection: IConnection;
     targetConnection: IConnection;
     exportFormat: IExportFormat;
-    videoSettings: IVideoSettings;
+    videoSettings: IProjectVideoSettings;
     autoSave: boolean;
     assets?: { [index: string]: IAsset };
 }
@@ -120,12 +120,25 @@ export interface IExportFormat {
 }
 
 /**
- * @name - Video Tagging Settings
+ * @name - Video Tagging Settings for the project
  * @description - Defines the video settings within a VoTT project
  * @member frameExtractionRate - Extraction rate for a video (number of frames per second of video)
  */
-export interface IVideoSettings {
+export interface IProjectVideoSettings {
     frameExtractionRate: number;
+}
+
+/**
+ * @name - Asset Video Settings
+ * @description - Defines the settings for video assets
+ * @member shouldAutoPlayVideo - true if the video should auto play when loaded, false otherwise
+ * @member posterSource - Source location of the image to display when the video is not playing,
+ * null for default (first frame of video)
+ */
+export interface IAssetVideoSettings {
+    shouldAutoPlayVideo: boolean;
+    posterSource: string;
+    shouldShowPlayControls: boolean;
 }
 
 /**

--- a/src/react/components/pages/editorPage/assetPreview.tsx
+++ b/src/react/components/pages/editorPage/assetPreview.tsx
@@ -52,13 +52,13 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                     </div>
                 }
                 {asset.type === AssetType.Image &&
-                    <img src={asset.path} onLoad={this.onAssetLoad} />
+                    <img src={this.checkAssetPathProtocol(asset.path)} onLoad={this.onAssetLoad} />
                 }
                 {asset.type === AssetType.Video &&
                     <Player ref={this.playerRef}
                         fluid={false} autoPlay={videoSettings.shouldAutoPlayVideo}
                         poster={videoSettings.posterSource}
-                        src={`${asset.path}`}
+                        src={`${this.checkAssetPathProtocol(asset.path)}`}
                     >
                     {videoSettings.shouldShowPlayControls &&
                         <ControlBar>
@@ -92,6 +92,13 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                 loaded: true,
             });
         }
+    }
+
+    private checkAssetPathProtocol(assetPath: string): string {
+        if (assetPath.toLowerCase().startsWith("http://") || assetPath.toLowerCase().startsWith("https://")) {
+            return assetPath;
+        }
+        return "file://" + assetPath;
     }
 
     private onAssetLoad() {

--- a/src/react/components/pages/editorPage/assetPreview.tsx
+++ b/src/react/components/pages/editorPage/assetPreview.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { IAsset, AssetType, IAssetVideoSettings } from "../../../../models/applicationState";
 import { strings } from "../../../../common/strings";
 import { Player, ControlBar, CurrentTimeDisplay, TimeDivider,
-    PlaybackRateMenuButton, VolumeMenuButton } from "video-react";
+    BigPlayButton, PlaybackRateMenuButton, VolumeMenuButton } from "video-react";
 
 /**
  * Properties for Asset Preview
@@ -56,10 +56,12 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                 }
                 {asset.type === AssetType.Video &&
                     <Player ref={this.playerRef}
-                        fluid={false} autoPlay={videoSettings.shouldAutoPlayVideo}
+                        fluid={true}
+                        autoPlay={videoSettings.shouldAutoPlayVideo}
                         poster={videoSettings.posterSource}
                         src={`${this.checkAssetPathProtocol(asset.path)}`}
                     >
+                    <BigPlayButton position="center" />
                     {videoSettings.shouldShowPlayControls &&
                         <ControlBar>
                             <CurrentTimeDisplay order={1.1} />
@@ -79,7 +81,7 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
 
     public componentDidMount() {
         // subscribe state change for the video if it has been loaded
-        if (this.playerRef != null && this.playerRef.current != null) {
+        if (this.playerRef && this.playerRef.current) {
             this.playerRef.current.subscribeToStateChange(this.handleVideoStateChange.bind(this));
         }
     }

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -1,4 +1,5 @@
 @import '../../../../assets/sass/theme.scss';
+@import "~video-react/styles/scss/video-react";
 
 .editor-page {
     display: flex;

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -99,7 +99,7 @@ describe("Editor Page Component", () => {
     });
 
     it("Raises onAssetSelected handler when an asset is selected from the sidebar", (done) => {
-        // create` test project and asset
+        // create test project and asset
         const testProject = MockFactory.createTestProject("TestProject");
         const testAssets = MockFactory.createTestAssets(5);
         const defaultAsset = testAssets[0];

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -134,7 +134,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     <div className="editor-page-content-body">
                         {selectedAsset &&
                             <div className="canvas-container">
-                                <AssetPreview asset={selectedAsset.asset} videoSettings={ editorVideoSetting} />
+                                <AssetPreview asset={selectedAsset.asset} videoSettings={editorVideoSetting} />
                                 {selectedAsset.asset.size &&
                                     <div>
                                         {strings.editorPage.width}: {selectedAsset.asset.size.width}

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -7,7 +7,7 @@ import { bindActionCreators } from "redux";
 import HtmlFileReader from "../../../../common/htmlFileReader";
 import { strings } from "../../../../common/strings";
 import { AssetState, IApplicationState, IAsset,
-    IAssetMetadata, IProject, ITag } from "../../../../models/applicationState";
+    IAssetMetadata, IProject, ITag, IAssetVideoSettings } from "../../../../models/applicationState";
 import { IToolbarItemRegistration, ToolbarItemFactory } from "../../../../providers/toolbar/toolbarItemFactory";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
 import AssetPreview from "./assetPreview";
@@ -106,6 +106,11 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
     public render() {
         const { project } = this.props;
         const { assets, selectedAsset } = this.state;
+        const editorVideoSetting: IAssetVideoSettings = {
+            shouldAutoPlayVideo: true,
+            posterSource: null,
+            shouldShowPlayControls: true,
+        };
 
         if (!project) {
             return (<div>Loading...</div>);
@@ -129,7 +134,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     <div className="editor-page-content-body">
                         {selectedAsset &&
                             <div className="canvas-container">
-                                <AssetPreview asset={selectedAsset.asset} />
+                                <AssetPreview asset={selectedAsset.asset} videoSettings={ editorVideoSetting} />
                                 {selectedAsset.asset.size &&
                                     <div>
                                         {strings.editorPage.width}: {selectedAsset.asset.size.width}

--- a/src/react/components/pages/editorPage/editorSideBar.test.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.test.tsx
@@ -3,6 +3,7 @@ import EditorSideBar, { IEditorSideBarProps } from "./editorSideBar";
 import { ReactWrapper, mount } from "enzyme";
 import { AutoSizer, List } from "react-virtualized";
 import { IAsset, AssetState, AssetType } from "../../../../models/applicationState";
+import MockFactory from "../../../../common/mockFactory";
 
 describe("Editor SideBar", () => {
     const onSelectAssetHanlder = jest.fn();
@@ -13,7 +14,7 @@ describe("Editor SideBar", () => {
 
     it("Component renders correctly", () => {
         const props: IEditorSideBarProps = {
-            assets: getTestAssets(),
+            assets: MockFactory.createTestAssets(),
             onAssetSelected: onSelectAssetHanlder,
         };
 
@@ -25,7 +26,7 @@ describe("Editor SideBar", () => {
 
     it("Initializes state without asset selected", () => {
         const props: IEditorSideBarProps = {
-            assets: getTestAssets(),
+            assets: MockFactory.createTestAssets(),
             onAssetSelected: onSelectAssetHanlder,
         };
 
@@ -34,7 +35,7 @@ describe("Editor SideBar", () => {
     });
 
     it("Initializes state with asset selected", () => {
-        const testAssets = getTestAssets();
+        const testAssets = MockFactory.createTestAssets();
         const props: IEditorSideBarProps = {
             assets: testAssets,
             selectedAsset: testAssets[0],
@@ -46,7 +47,7 @@ describe("Editor SideBar", () => {
     });
 
     it("Updates states after props have changed", (done) => {
-        const testAssets = getTestAssets();
+        const testAssets = MockFactory.createTestAssets();
         const props: IEditorSideBarProps = {
             assets: testAssets,
             selectedAsset: null,
@@ -65,7 +66,7 @@ describe("Editor SideBar", () => {
     });
 
     it("Calls onAssetSelected handler when an asset is selected", (done) => {
-        const testAssets = getTestAssets();
+        const testAssets = MockFactory.createTestAssets();
         const props: IEditorSideBarProps = {
             assets: testAssets,
             selectedAsset: testAssets[0],
@@ -84,21 +85,37 @@ describe("Editor SideBar", () => {
             done();
         });
     });
-});
 
-function getTestAssets(count: number = 10): IAsset[] {
-    const assets: IAsset[] = [];
-    for (let i = 1; i <= count; i++) {
-        assets.push({
-            id: `asset-${i}`,
-            name: `Asset ${i}`,
-            format: "jpg",
-            path: `http://myserver.com/asset-${i}.jpg`,
-            size: null,
-            state: AssetState.NotVisited,
-            type: AssetType.Image,
+    it("Correctly switches from image to video and back", (done) => {
+        const testAssets = MockFactory.createTestAssets();
+        const props: IEditorSideBarProps = {
+            assets: testAssets,
+            selectedAsset: testAssets[0],
+            onAssetSelected: onSelectAssetHanlder,
+        };
+
+        const nextAsset = testAssets[6];
+        const wrapper = createComponent(props);
+        wrapper.setProps({
+            selectedAsset: nextAsset,
         });
-    }
 
-    return assets;
-}
+        setImmediate(() => {
+            expect(wrapper.state()["selectedAsset"]).toEqual(nextAsset);
+            expect(onSelectAssetHanlder).toBeCalledWith(nextAsset);
+            done();
+        });
+
+        const originalAsset = testAssets[0];
+        const backToOriginalwrapper = createComponent(props);
+        backToOriginalwrapper.setProps({
+            selectedAsset: originalAsset,
+        });
+
+        setImmediate(() => {
+            expect(backToOriginalwrapper.state()["selectedAsset"]).toEqual(originalAsset);
+            expect(onSelectAssetHanlder).toBeCalledWith(originalAsset);
+            done();
+        });
+    });
+});

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AutoSizer, List } from "react-virtualized";
-import { IAsset, AssetState } from "../../../../models/applicationState";
+import { IAsset, AssetState, IAssetVideoSettings } from "../../../../models/applicationState";
 import AssetPreview from "./assetPreview";
 
 /**
@@ -90,13 +90,18 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private rowRenderer({ key, index, style }) {
         const asset = this.props.assets[index];
         const { selectedAsset } = this.state;
+        const editorVideoSetting: IAssetVideoSettings = {
+            shouldAutoPlayVideo: false,
+            posterSource: null,
+            shouldShowPlayControls: false,
+        };
 
         return (
             <div key={key} style={style}
                 className={this.getAssetCssClassNames(asset, selectedAsset)}
                 onClick={() => this.onAssetClicked(asset)}>
                 <div className="asset-item-image">
-                    <AssetPreview asset={asset} />
+                    <AssetPreview asset={asset} videoSettings={editorVideoSetting} />
                 </div>
                 <div className="asset-item-metadata">
                     <span className="asset-filename" title={asset.name}>{asset.name}</span>

--- a/src/react/components/pages/projectSettings/projectForm.test.tsx
+++ b/src/react/components/pages/projectSettings/projectForm.test.tsx
@@ -5,7 +5,7 @@ import MockFactory from "../../../../common/mockFactory";
 import { KeyCodes } from "../../../../common/utils";
 import registerProviders from "../../../../registerProviders";
 import ProjectForm, { IProjectFormProps, IProjectFormState } from "./projectForm";
-import { IVideoSettings } from "../../../../models/applicationState";
+import { IProjectVideoSettings } from "../../../../models/applicationState";
 
 describe("Project Form Component", () => {
     const project = MockFactory.createTestProject("TestProject");
@@ -200,7 +200,7 @@ describe("Project Form Component", () => {
         });
         it("Has initial state loaded correctly", () => {
             const formData = wrapper.state().formData;
-            const defaultVideoSettings: IVideoSettings = { frameExtractionRate: 15 };
+            const defaultVideoSettings: IProjectVideoSettings = { frameExtractionRate: 15 };
             expect(formData.name).toBe(undefined);
             expect(formData.sourceConnection).toEqual({});
             expect(formData.targetConnection).toEqual({});


### PR DESCRIPTION
Initial implementation of simple video player on editor page
- Includes video player with customizable playback speed
- Auto plays selected videos
- No longer auto plays videos in side bar
- Supports custom image to display when video not playing (defaults to 1st video frame)
- Updates tests
- Refactors a few other tests to centralize test asset creation
- Updates version of React to 16.7.0
- Rename IVideoSettings to IProjectVideoSettings for clarity