### PR TITLE
Quick fix for navigation error, not correct fix, but to unblock people. AB#16759

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,14 +60,12 @@ class App extends React.Component<IAppProps> {
                         show={showError}
                         onClose={this.props.actions.clearError}
                     />
-                    <ErrorBoundary>
-                        <Navbar />
-                        <div className="app-main">
-                            <Sidebar project={this.props.currentProject} />
-                            <MainContentRouter />
-                        </div>
-                        <ToastContainer />
-                    </ErrorBoundary>
+                    <Navbar />
+                    <div className="app-main">
+                        <Sidebar project={this.props.currentProject} />
+                        <MainContentRouter />
+                    </div>
+                    <ToastContainer />
                 </div>
             </Router>
         );


### PR DESCRIPTION
Temporarily removing ErrorBoundary from Render call to fix navigation and unblock people while correct fix is investigated.