### PR TITLE
enable CI for greenkeeper created branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
   - v2 # disable CI build for branch except v2
+  - greenkeeper/* # enable CI to run on greepkeeper branches
 pr:
   - v2 # only kick off for pr targeting v2
 


### PR DESCRIPTION
in order to test and integrate [greenkeeper](https://greenkeeper.io/) I have to enable CI on branches (right now it's disable).  But I don't want this to run for all branches, so only enable it on greenkeeper-created branches which always starts with `greenkeeper/`