### PR TITLE
Updating Canvas to handle Videos and allow tagging - AB#16580

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -200,5 +200,9 @@ export const english: IAppStrings = {
             message: `The security token referenced by the project cannot be found in your current application settings.
                 Verify the security token exists and try to reload the project.`,
         },
+        canvasError: {
+            title: "Error loading canvas",
+            message: "There was an error loading the canvas, check the project's assets and try again.",
+        },
     },
 };

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -201,5 +201,10 @@ export const spanish: IAppStrings = {
                 configuración de la aplicación actual. Compruebe que existe el token de seguridad e intente
                 volver a cargar el proyecto.`,
         },
+        canvasError: {
+            title: "Error al cargar el lienzo",
+            message: `Se produjo un error al cargar el lienzo, verifique los activos del
+                proyecto y vuelva a intentarlo.`,
+        },
     },
 };

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -96,40 +96,6 @@ export default class MockFactory {
     }
 
     /**
-     * @name Create Unknown Asset type
-     * @description Creates fake IAsset with unknown type
-     * @param name Name of asset
-     * @param assetState State of asset
-     */
-    public static createUnknownTestAsset(name: string, assetState: AssetState = AssetState.NotVisited): IAsset {
-        return {
-            id: `unkasset-${name}`,
-            format: ".docx",
-            name: `Unknown Asset ${name}`,
-            path: `C:\\Desktop\\unkasset${name}.docx`,
-            state: assetState,
-            type: AssetType.Unknown,
-            size: {
-                width: 800,
-                height: 600,
-            },
-        };
-    }
-
-    /**
-     * Creates array of fake IAsset with unknown types
-     * @param count Number of assets to create
-     */
-    public static createUnknownTypeTestAssets(count: number = 5): IAsset[] {
-        const assets: IAsset[] = [];
-        for (let i = 1; i <= count; i++) {
-            assets.push(MockFactory.createUnknownTestAsset(i.toString()));
-        }
-
-        return assets;
-    }
-
-    /**
      * Creates a mock region
      */
     public static createMockRegion(): IRegion {

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -97,16 +97,16 @@ export default class MockFactory {
     /**
      * Creates array of fake IAsset
      * @param count Number of assets to create
+     * @param videoFirst true if the first asset should be video; false otherwise
      */
-    public static createTestAssets(count: number = 10): IAsset[] {
+    public static createTestAssets(count: number = 10, videoFirst: boolean = true): IAsset[] {
         const assets: IAsset[] = [];
-        for (let i = 1; i <= count / 2; i++) {
-            assets.push(MockFactory.createVideoTestAsset(i.toString()));
-        }
-        if (count > 1) {
-            for (let i = 1; i <= count / 2; i++) {
-                assets.push(MockFactory.createTestAsset(i.toString()));
-            }
+        for (let i = 1; i <= count; i++) {
+            assets.push((i % 2 === 1) ?
+                videoFirst ? MockFactory.createVideoTestAsset(i.toString()) :
+                    MockFactory.createTestAsset(i.toString()) :
+                !videoFirst ? MockFactory.createVideoTestAsset(i.toString()) :
+                    MockFactory.createTestAsset(i.toString()));
         }
 
         return assets;

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -2,7 +2,8 @@ import shortid from "shortid";
 import {
     AssetState, AssetType, IApplicationState, IAppSettings, IAsset, IAssetMetadata,
     IConnection, IExportFormat, IProject, ITag, StorageType, ISecurityToken,
-    EditorMode, IAppError, IProjectVideoSettings, AppError, ErrorCode,
+    EditorMode, IAppError, IProjectVideoSettings, AppError, ErrorCode, ITagMetadata,
+    IPoint, IRegion, RegionType, IBoundingBox,
 } from "../models/applicationState";
 import { ExportAssetState } from "../providers/export/exportProvider";
 import { IAssetProvider, IAssetProviderRegistrationOptions } from "../providers/storage/assetProviderFactory";
@@ -92,6 +93,77 @@ export default class MockFactory {
                 height: 600,
             },
         };
+    }
+
+    /**
+     * @name Create Unknown Asset type
+     * @description Creates fake IAsset with unknown type
+     * @param name Name of asset
+     * @param assetState State of asset
+     */
+    public static createUnknownTestAsset(name: string, assetState: AssetState = AssetState.NotVisited): IAsset {
+        return {
+            id: `unkasset-${name}`,
+            format: ".docx",
+            name: `Unknown Asset ${name}`,
+            path: `C:\\Desktop\\unkasset${name}.docx`,
+            state: assetState,
+            type: AssetType.Unknown,
+            size: {
+                width: 800,
+                height: 600,
+            },
+        };
+    }
+
+    /**
+     * Creates array of fake IAsset with unknown types
+     * @param count Number of assets to create
+     */
+    public static createUnknownTypeTestAssets(count: number = 5): IAsset[] {
+        const assets: IAsset[] = [];
+        for (let i = 1; i <= count; i++) {
+            assets.push(MockFactory.createUnknownTestAsset(i.toString()));
+        }
+
+        return assets;
+    }
+
+    /**
+     * Creates a mock region
+     */
+    public static createMockRegion(): IRegion {
+        const mockTag: ITagMetadata = {
+            name: "Tag 1",
+            properties: null,
+        };
+
+        const mockStartPoint: IPoint = {
+            x: 1,
+            y: 2,
+        };
+
+        const mockEndPoint: IPoint = {
+            x: 3,
+            y: 4,
+        };
+
+        const mockBoundingBox: IBoundingBox = {
+            left: 0,
+            top: 0,
+            width: 256,
+            height: 256,
+        };
+
+        const mockRegion: IRegion = {
+            id: "id",
+            type: RegionType.Rectangle,
+            tags: [mockTag],
+            points: [mockStartPoint, mockEndPoint],
+            boundingBox: mockBoundingBox,
+        };
+
+        return mockRegion;
     }
 
     /**

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -182,6 +182,7 @@ export interface IAppStrings {
         projectUploadError: IErrorMetadata,
         genericRenderError: IErrorMetadata,
         securityTokenNotFound: IErrorMetadata,
+        canvasError: IErrorMetadata,
     };
 }
 

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -42,6 +42,7 @@ export enum ErrorCode {
     ProjectInvalidSecurityToken = "projectInvalidSecurityToken",
     ProjectUploadError = "projectUploadError",
     SecurityTokenNotFound = "securityTokenNotFound",
+    CanvasError = "canvasError",
 }
 
 /**

--- a/src/react/components/pages/editorPage/assetPreview.tsx
+++ b/src/react/components/pages/editorPage/assetPreview.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { IAsset, AssetType, IAssetVideoSettings } from "../../../../models/applicationState";
 import { strings } from "../../../../common/strings";
-import { Player, ControlBar, CurrentTimeDisplay, TimeDivider,
-    BigPlayButton, PlaybackRateMenuButton, VolumeMenuButton } from "video-react";
 
 /**
  * Properties for Asset Preview
@@ -26,7 +24,6 @@ interface IAssetPreviewState {
  * @description - Small preview of assets for selection in editor page
  */
 export default class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPreviewState> {
-    private playerRef: React.RefObject<Player>;
 
     constructor(props, context) {
         super(props, context);
@@ -36,7 +33,6 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
         };
 
         this.onAssetLoad = this.onAssetLoad.bind(this);
-        this.playerRef = React.createRef<Player>();
     }
 
     public render() {
@@ -55,45 +51,15 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                     <img src={asset.path} onLoad={this.onAssetLoad} />
                 }
                 {asset.type === AssetType.Video &&
-                    <Player ref={this.playerRef}
-                        fluid={true}
-                        autoPlay={videoSettings.shouldAutoPlayVideo}
-                        poster={videoSettings.posterSource}
-                        src={`${asset.path}`}
-                    >
-                    <BigPlayButton position="center" />
-                    {videoSettings.shouldShowPlayControls &&
-                        <ControlBar>
-                            <CurrentTimeDisplay order={1.1} />
-                            <TimeDivider order={1.2} />
-                            <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.25]} order={7.1} />
-                            <VolumeMenuButton enabled order={7.2} />
-                        </ControlBar>
-                    }
-                    </Player>
+                    <video onLoadedData={this.onAssetLoad}>
+                        <source src={`${asset.path}#t=5.0`} />
+                    </video>
                 }
                 {asset.type === AssetType.Unknown &&
                     <div>{strings.editorPage.assetError}</div>
                 }
             </div>
         );
-    }
-
-    public componentDidMount() {
-        // subscribe state change for the video if it has been loaded
-        if (this.playerRef && this.playerRef.current) {
-            this.playerRef.current.subscribeToStateChange(this.handleVideoStateChange.bind(this));
-        }
-    }
-
-    private handleVideoStateChange(state, previousState) {
-        // When we have a duration, and we've buffered some data, we will mark
-        // the asset as loaded
-        if ((state.duration > 0) && (state.buffered.length > 0)) {
-            this.setState({
-                loaded: true,
-            });
-        }
     }
 
     private onAssetLoad() {

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -252,7 +252,6 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         // const { loaded } = this.state;
         // const { svgHost } = this.props;
         const { selectedAsset } = this.props;
-        const validHeight = selectedAsset.asset.type === AssetType.Video ? "95%" : "100%";
 
         return (
                 <div id="ct-zone">
@@ -391,10 +390,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             image.src = this.props.selectedAsset.asset.path;
         } else if (this.props.selectedAsset.asset.type === AssetType.Video) {
             if (this.playerRef && this.playerRef.current && this.selectionRef && this.selectionRef.current) {
-                // Update the selection div to have 5px padding (same as the video player)
-                // and remove 3.0em from the height (height of the control bar)
+                // Update the selection div to remove 2.0em from the height (height of the control bar)
                 this.selectionRef.current.style.height = "calc(100% - 2.0em)";
-                this.playerRef.current.manager.rootElement.style.position = "absolute";
                 this.playerRef.current.subscribeToStateChange((state, prev) => {
                     // If the video is paused, add this frame to the editor content
                     if (state.paused && !state.waiting && state.hasStarted) {
@@ -416,7 +413,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                 // How do we want to handle this error case?
             }
         } else {
-            // How do we want to handle this error case? Is it an error case?
+            // How do we want to handle this error case? Is it an error case? We don't know what type of
+            // asset this is?
         }
     }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as shortid from "shortid";
-import { IAssetMetadata, IRegion, RegionType, IAppError,
-        AssetState, EditorMode, IProject, AssetType, ErrorCode } from "../../../../models/applicationState";
+import { IAssetMetadata, IRegion, RegionType, AppError, ErrorCode,
+        AssetState, EditorMode, IProject, AssetType } from "../../../../models/applicationState";
 import { CanvasTools } from "vott-ct";
 import { Player, ControlBar, CurrentTimeDisplay, TimeDivider,
     BigPlayButton, PlaybackRateMenuButton, VolumeMenuButton } from "video-react";
@@ -11,7 +11,6 @@ import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
 import { strings } from "../../../../common/strings";
-import { ErrorHandler, IErrorHandlerProps } from "../../../../react/components/common/errorHandler/errorHandler";
 
 export interface ICanvasProps {
     selectedAsset: IAssetMetadata;
@@ -383,7 +382,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             this.loadVideo();
         } else {
             // We don't know what type of asset this is?
-            throw new Error(strings.editorPage.assetError);
+            throw new AppError(ErrorCode.Unknown, strings.editorPage.assetError);
         }
     }
 
@@ -410,7 +409,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             });
         } else {
             // Something has gone majorly wrong to get to this spot
-            throw new Error(strings.errors.unknown.message);
+            throw new AppError(ErrorCode.Unknown, strings.errors.unknown.message);
         }
     }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -252,37 +252,27 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         const { selectedAsset } = this.props;
 
         return (
-            <React.Fragment>
-            {selectedAsset.asset.type === AssetType.Image &&
                 <div id="ct-zone">
+                    { selectedAsset.asset.type === AssetType.Video &&
+                        <Player ref={this.playerRef}
+                            fluid={false} width={"100%"} height={"100%"}
+                            autoPlay={true}
+                            poster={""}
+                            src={`${selectedAsset.asset.path}`}
+                        >
+                            <BigPlayButton position="center" />
+                            <ControlBar>
+                                <CurrentTimeDisplay order={1.1} />
+                                <TimeDivider order={1.2} />
+                                <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.25]} order={7.1} />
+                                <VolumeMenuButton enabled order={7.2} />
+                            </ControlBar>
+                        </Player>
+                    }
                     <div id="selection-zone">
                         <div id="editor-zone" className="full-size" />
                     </div>
-                </div>
-            }
-            { selectedAsset.asset.type === AssetType.Video &&
-                <div id="ct-zone">
-                    <div id="selection-zone">
-                        <div id="editor-zone" className="full-size">
-                        </div>
-                    </div>
-                    <Player ref={this.playerRef}
-                        fluid={false} width={"100%"} height={"100%"}
-                        autoPlay={true}
-                        poster={""}
-                        src={`${selectedAsset.asset.path}`}
-                    >
-                        <BigPlayButton position="center" />
-                        <ControlBar>
-                            <CurrentTimeDisplay order={1.1} />
-                            <TimeDivider order={1.2} />
-                            <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.25]} order={7.1} />
-                            <VolumeMenuButton enabled order={7.2} />
-                        </ControlBar>
-                    </Player>
-                </div>
-            }
-            </React.Fragment>
+            </div>
             );
     }
 
@@ -401,8 +391,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                 this.playerRef.current.subscribeToStateChange((state, prev) => {
                     // If the video is paused, add this frame to the editor content
                     if (state.paused && !state.waiting && state.hasStarted) {
+                        // If we're paused, make sure we're behind the canvas so we can tag
+                        this.playerRef.current.manager.rootElement.style.zIndex = 0;
                         this.updateRegions();
                     } else if (!state.paused) {
+                        // We need to make sure we're on top if we are playing
+                        this.playerRef.current.manager.rootElement.style.zIndex = 9001;
                         this.editor.addContentSource(this.playerRef.current.video.video);
                     }
                 });

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -382,7 +382,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             this.loadVideo();
         } else {
             // We don't know what type of asset this is?
-            throw new AppError(ErrorCode.Unknown, strings.editorPage.assetError);
+            throw new AppError(ErrorCode.CanvasError, strings.editorPage.assetError);
         }
     }
 
@@ -409,7 +409,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             });
         } else {
             // Something has gone majorly wrong to get to this spot
-            throw new AppError(ErrorCode.Unknown, strings.errors.unknown.message);
+            throw new AppError(ErrorCode.CanvasError, strings.errors.unknown.message);
         }
     }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as shortid from "shortid";
-import { IAssetMetadata, IRegion, RegionType,
-        AssetState, EditorMode, IProject, AssetType } from "../../../../models/applicationState";
+import { IAssetMetadata, IRegion, RegionType, IAppError,
+        AssetState, EditorMode, IProject, AssetType, ErrorCode } from "../../../../models/applicationState";
 import { CanvasTools } from "vott-ct";
 import { Player, ControlBar, CurrentTimeDisplay, TimeDivider,
     BigPlayButton, PlaybackRateMenuButton, VolumeMenuButton } from "video-react";
@@ -10,6 +10,8 @@ import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/Regi
 import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
+import { strings } from "../../../../common/strings";
+import { ErrorHandler, IErrorHandlerProps } from "../../../../react/components/common/errorHandler/errorHandler";
 
 export interface ICanvasProps {
     selectedAsset: IAssetMetadata;
@@ -260,6 +262,10 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             }
             { selectedAsset.asset.type === AssetType.Video &&
                 <div id="ct-zone">
+                    <div id="selection-zone">
+                        <div id="editor-zone" className="full-size">
+                        </div>
+                    </div>
                     <Player ref={this.playerRef}
                         fluid={false} width={"100%"} height={"100%"}
                         autoPlay={true}
@@ -274,10 +280,6 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                             <VolumeMenuButton enabled order={7.2} />
                         </ControlBar>
                     </Player>
-                    <div id="selection-zone">
-                        <div id="editor-zone" className="full-size">
-                        </div>
-                    </div>
                 </div>
             }
             </React.Fragment>
@@ -395,18 +397,21 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             });
             image.src = this.props.selectedAsset.asset.path;
         } else if (this.props.selectedAsset.asset.type === AssetType.Video) {
-            this.freeze("Video playing");
             if (this.playerRef && this.playerRef.current) {
                 this.playerRef.current.subscribeToStateChange((state, prev) => {
                     // If the video is paused, add this frame to the editor content
                     if (state.paused && !state.waiting && state.hasStarted) {
-                        this.unfreeze();
                         this.updateRegions();
                     } else if (!state.paused) {
                         this.editor.addContentSource(this.playerRef.current.video.video);
                     }
                 });
             } else {
+                const errorInfo: IAppError = {
+                    errorCode: ErrorCode.Unknown,
+                    message: strings.errors.unknown.message,
+                    title: strings.errors.unknown.title,
+                };
                 // How do we want to handle this error case?
             }
         } else {

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -393,8 +393,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             if (this.playerRef && this.playerRef.current && this.selectionRef && this.selectionRef.current) {
                 // Update the selection div to have 5px padding (same as the video player)
                 // and remove 3.0em from the height (height of the control bar)
-                this.selectionRef.current.style.padding = "5px";
-                this.selectionRef.current.style.height = "calc(100% - 3.0em)";
+                this.selectionRef.current.style.height = "calc(100% - 2.0em)";
+                this.playerRef.current.manager.rootElement.style.position = "absolute";
                 this.playerRef.current.subscribeToStateChange((state, prev) => {
                     // If the video is paused, add this frame to the editor content
                     if (state.paused && !state.waiting && state.hasStarted) {

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -104,9 +104,16 @@
                 }
             }
 
-            img, video {
+            img {
                 display: inline-block;
                 margin: auto;
+                max-width: 100%;
+                max-height: 100%;
+            }
+
+            video {
+                display: inline-block;
+                margin: 0px;
                 max-width: 100%;
                 max-height: 100%;
             }

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -104,16 +104,9 @@
                 }
             }
 
-            img {
+            img, video {
                 display: inline-block;
                 margin: auto;
-                max-width: 100%;
-                max-height: 100%;
-            }
-
-            video {
-                display: inline-block;
-                margin: 0px;
                 max-width: 100%;
                 max-height: 100%;
             }

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -133,13 +133,19 @@
 }
 
 #ct-zone {
+    position: relative;
     flex-grow: 1;
     padding: 5px;
 }
 
 #selection-zone {
+    position: absolute;
     padding: 5px;
+    top: 0;
+    left: 0;
     height: 100%;
+    width: 100%;
+    z-index: 0;
     background-color: $lighter-3;
 }
 

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -140,7 +140,6 @@
 
 #selection-zone {
     position: absolute;
-    padding: 5px;
     top: 0;
     left: 0;
     height: 100%;

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -142,7 +142,6 @@
 #ct-zone {
     position: relative;
     flex-grow: 1;
-    padding: 5px;
 }
 
 #selection-zone {

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -52,7 +52,7 @@ describe("Editor Page Component", () => {
         assetServiceMock.prototype.getAssetMetadata = jest.fn((asset) => {
             const assetMetadata: IAssetMetadata = {
                 asset: { ...asset },
-                regions: [],
+                regions: [MockFactory.createMockRegion()],
                 timestamp: null,
             };
             return Promise.resolve(assetMetadata);

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -17,6 +17,7 @@ import { DrawPolygon } from "../../toolbar/drawPolygon";
 import { DrawRectangle } from "../../toolbar/drawRectangle";
 import { Select } from "../../toolbar/select";
 import { Pan } from "../../toolbar/pan";
+import { Player } from "video-react";
 
 jest.mock("../../../../services/projectService");
 
@@ -37,6 +38,8 @@ function getState(wrapper) {
 describe("Editor Page Component", () => {
     let assetServiceMock: jest.Mocked<typeof AssetService> = null;
     let projectServiceMock: jest.Mocked<typeof ProjectService> = null;
+    let videoPlayerPausedMock: jest.Mocked<typeof Player> = null;
+    let videoPlayerUnpausedMock: jest.Mocked<typeof Player> = null;
 
     beforeAll(() => {
         const editorMock = CanvasTools.Editor as any;
@@ -92,6 +95,16 @@ describe("Editor Page Component", () => {
         });
 
         let savedAssetMetadata: IAssetMetadata = null;
+        videoPlayerPausedMock = Player as jest.Mocked<typeof Player>;
+        videoPlayerPausedMock.prototype.subscribeToStateChange = jest.fn((callback) => {
+            // Set up some state that is unpaused
+            const state = {
+                paused: true,
+                waiting: false,
+                hasStarted: true,
+            };
+            callback(state, state);
+        });
 
         assetServiceMock.prototype.save = jest.fn((assetMetadata) => {
             savedAssetMetadata = { ...assetMetadata };
@@ -132,6 +145,16 @@ describe("Editor Page Component", () => {
         });
 
         let savedAssetMetadata: IAssetMetadata = null;
+        videoPlayerUnpausedMock = Player as jest.Mocked<typeof Player>;
+        videoPlayerUnpausedMock.prototype.subscribeToStateChange = jest.fn((callback) => {
+            // Set up some state that is unpaused
+            const state = {
+                paused: false,
+                waiting: false,
+                hasStarted: true,
+            };
+            callback(state, state);
+        });
 
         // mock out the asset service save method
         assetServiceMock.prototype.save = jest.fn((assetMetadata) => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -151,7 +151,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                 selectedAsset={this.state.selectedAsset}
                                 onAssetMetadataChanged={this.onAssetMetadataChanged}
                                 editorMode={this.state.mode}
-                                project={this.props.project} />
+                                project={this.props.project}/>
                         }
                     </div>
                     <div>

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -151,7 +151,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                 selectedAsset={this.state.selectedAsset}
                                 onAssetMetadataChanged={this.onAssetMetadataChanged}
                                 editorMode={this.state.mode}
-                                project={this.props.project}/>
+                                project={this.props.project} />
                         }
                     </div>
                     <div>


### PR DESCRIPTION
- Hook video player into canvas
- Update styles base on pause state to allow tagging of individual frames of video
- Remove video player component from AssetPreview (more simplified)