### PR TITLE
Import TFRecords assets

### DIFF
--- a/src/common/htmlFileReader.test.ts
+++ b/src/common/htmlFileReader.test.ts
@@ -130,32 +130,55 @@ describe("Html File Reader", () => {
         });
     });
 
-    it("Loads attributes for an tfrecord asset", async () => {
-        const expected = {
-            width: 1920,
-            height: 1080,
-        };
-
-        axios.get = jest.fn((url, config) => {
-            const builder = new TFRecordsBuilder();
-            builder.addFeature("image/height", FeatureType.Int64, expected.height);
-            builder.addFeature("image/width", FeatureType.Int64, expected.width);
-            const buffer = builder.build();
-            const tfrecords = TFRecordsBuilder.buildTFRecords([buffer]);
-
-            return Promise.resolve<AxiosResponse>({
-                config,
-                headers: null,
-                status: 200,
-                statusText: "OK",
-                data: tfrecords,
+    describe("Test non valid asset type", () => {
+        it("Test non valid asset type", async () => {
+            axios.get = jest.fn((url, config) => {
+                return Promise.resolve<AxiosResponse>({
+                    config,
+                    headers: null,
+                    status: 200,
+                    statusText: "OK",
+                    data: [1, 2, 3],
+                });
             });
+
+            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.notsupported");
+            try {
+                const result = await HtmlFileReader.readAssetAttributes(imageAsset);
+            } catch (error) {
+                expect(error).toEqual(new Error("Asset not supported"));
+            }
         });
+    });
 
-        const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord");
-        const result = await HtmlFileReader.readAssetAttributes(imageAsset);
+    describe("Test TFRecords", () => {
+        it("Loads attributes for an tfrecord asset", async () => {
+            const expected = {
+                width: 1920,
+                height: 1080,
+            };
 
-        expect(result.width).toEqual(expected.width);
-        expect(result.height).toEqual(expected.height);
+            axios.get = jest.fn((url, config) => {
+                const builder = new TFRecordsBuilder();
+                builder.addFeature("image/height", FeatureType.Int64, expected.height);
+                builder.addFeature("image/width", FeatureType.Int64, expected.width);
+                const buffer = builder.build();
+                const tfrecords = TFRecordsBuilder.buildTFRecords([buffer]);
+
+                return Promise.resolve<AxiosResponse>({
+                    config,
+                    headers: null,
+                    status: 200,
+                    statusText: "OK",
+                    data: tfrecords,
+                });
+            });
+
+            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord");
+            const result = await HtmlFileReader.readAssetAttributes(imageAsset);
+
+            expect(result.width).toEqual(expected.width);
+            expect(result.height).toEqual(expected.height);
+        });
     });
 });

--- a/src/common/htmlFileReader.ts
+++ b/src/common/htmlFileReader.ts
@@ -122,13 +122,14 @@ export default class HtmlFileReader {
     }
 
     private static readTFRecordAttributes(asset: IAsset): Promise<{ width: number, height: number }> {
-        // TODO: Get from TFRecord Reader
+        // Get from TFRecord Reader
         return new Promise(async (resolve, reject) => {
             const tfrecords = new Buffer(await this.getAssetArray(asset));
             const reader = new TFRecordsReader(tfrecords);
-            const value = reader.getFeature(0, "image/height", FeatureType.Int64);
+            const width = reader.getFeature(0, "image/width", FeatureType.Int64) as number;
+            const height = reader.getFeature(0, "image/height", FeatureType.Int64) as number;
 
-            return resolve({ width: 100, height: 100 });
+            return resolve({ width, height });
         });
     }
 }

--- a/src/common/htmlFileReader.ts
+++ b/src/common/htmlFileReader.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { IAsset, AssetType } from "../models/applicationState";
 import Guard from "./guard";
+import { TFRecordsReader } from "../providers/export/tensorFlowRecords/tensorFlowReader";
+import { FeatureType } from "../providers/export/tensorFlowRecords/tensorFlowBuilder";
 
 /**
  * Helper class for reading HTML files
@@ -46,6 +48,8 @@ export default class HtmlFileReader {
                 return await this.readImageAttributes(asset.path);
             case AssetType.Video:
                 return await this.readVideoAttributes(asset.path);
+            case AssetType.TFRecord:
+                return await this.readTFRecordAttributes(asset);
             default:
                 throw new Error("Asset not supported");
         }
@@ -114,6 +118,17 @@ export default class HtmlFileReader {
             };
             image.onerror = reject;
             image.src = url;
+        });
+    }
+
+    private static readTFRecordAttributes(asset: IAsset): Promise<{ width: number, height: number }> {
+        // TODO: Get from TFRecord Reader
+        return new Promise(async (resolve, reject) => {
+            const tfrecords = new Buffer(await this.getAssetArray(asset));
+            const reader = new TFRecordsReader(tfrecords);
+            const value = reader.getFeature(0, "image/height", FeatureType.Int64);
+
+            return resolve({ width: 100, height: 100 });
         });
     }
 }

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -294,6 +294,7 @@ export enum AssetType {
     Unknown = 0,
     Image = 1,
     Video = 2,
+    TFRecord = 3,
 }
 
 /**

--- a/src/providers/export/tensorFlowRecords/tensorFlowHelpers.test.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowHelpers.test.ts
@@ -1,4 +1,4 @@
-import { crc32c, maskCrc, getInt64Buffer, getInt32Buffer, textEncode } from "./tensorFlowHelpers";
+import { crc32c, maskCrc, getInt64Buffer, getInt32Buffer, textEncode, textDecode } from "./tensorFlowHelpers";
 
 describe("TFRecords Helper Functions", () => {
     describe("Run getInt64Buffer method test", () => {
@@ -35,6 +35,12 @@ describe("TFRecords Helper Functions", () => {
     describe("Run textEncode method test", () => {
         it("Check textEncode for string 'ABC123'", async () => {
             expect(textEncode("ABC123")).toEqual(new Uint8Array([65, 66, 67, 49, 50, 51]));
+        });
+    });
+
+    describe("Run textDecode method test", () => {
+        it("Check textDecode for array [65, 66, 67, 49, 50, 51]", async () => {
+            expect(textDecode(new Uint8Array([65, 66, 67, 49, 50, 51]))).toEqual("ABC123");
         });
     });
 });

--- a/src/providers/export/tensorFlowRecords/tensorFlowHelpers.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowHelpers.ts
@@ -133,6 +133,17 @@ export function textEncode(str: string): Uint8Array {
 }
 
 /**
+ * @arr - Input Uint8Array byte array
+ * @description - Get a UTF8 string value
+ */
+export function textDecode(arr: Uint8Array): string {
+    Guard.null(arr);
+
+    const utf8 = Array.from(arr).map((item) => String.fromCharCode(item)).join("");
+    return decodeURIComponent(escape(utf8));
+}
+
+/**
  * @buffer - Input buffer
  * @description - Read an Int64 value from buffer
  */

--- a/src/providers/export/tensorFlowRecords/tensorFlowReader.test.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowReader.test.ts
@@ -73,5 +73,20 @@ describe("TFRecords Reader/Builder Integration test", () => {
             expect(jsonImage[1]["context"].featureMap[1][1]["floatList"]["valueList"].length).toEqual(2);
             expect(jsonImage[1]["context"].featureMap[2][1]["bytesList"]["valueList"].length).toEqual(2);
         });
+
+        it("Check feature value on a single TFRecord", async () => {
+            builder.addFeature("feature/1", FeatureType.Int64, 12345);
+            builder.addFeature("feature/2", FeatureType.String, "12345");
+
+            const buffer = builder.build();
+            const tfrecords = TFRecordsBuilder.buildTFRecords([buffer]);
+
+            const reader = new TFRecordsReader(tfrecords);
+            const intValue = reader.getFeature(0, "feature/1", FeatureType.Int64) as number;
+            const stringValue = reader.getFeature(0, "feature/2", FeatureType.String) as string;
+
+            expect(intValue).toEqual(12345);
+            expect(stringValue).toEqual("12345");
+        });
     });
 });

--- a/src/providers/export/tensorFlowRecords/tensorFlowReader.test.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowReader.test.ts
@@ -77,6 +77,8 @@ describe("TFRecords Reader/Builder Integration test", () => {
         it("Check feature value on a single TFRecord", async () => {
             builder.addFeature("feature/1", FeatureType.Int64, 12345);
             builder.addFeature("feature/2", FeatureType.String, "12345");
+            builder.addFeature("feature/3", FeatureType.Float, 12345.0);
+            builder.addFeature("feature/4", FeatureType.Binary, new Uint8Array([1, 2, 3, 4, 5]));
 
             const buffer = builder.build();
             const tfrecords = TFRecordsBuilder.buildTFRecords([buffer]);
@@ -84,9 +86,13 @@ describe("TFRecords Reader/Builder Integration test", () => {
             const reader = new TFRecordsReader(tfrecords);
             const intValue = reader.getFeature(0, "feature/1", FeatureType.Int64) as number;
             const stringValue = reader.getFeature(0, "feature/2", FeatureType.String) as string;
+            const floatValue = reader.getFeature(0, "feature/3", FeatureType.Float) as number;
+            const binaryValue = reader.getFeature(0, "feature/4", FeatureType.Binary) as Uint8Array;
 
             expect(intValue).toEqual(12345);
             expect(stringValue).toEqual("12345");
+            expect(floatValue).toEqual(12345.0);
+            expect(binaryValue).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
         });
     });
 });

--- a/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
@@ -1,7 +1,7 @@
 import Guard from "../../../common/guard";
 import { TFRecordsImageMessage, Features, Feature, FeatureList,
     BytesList, Int64List, FloatList } from "./tensorFlowRecordsProtoBuf_pb";
-import { crc32c, maskCrc, getInt64Buffer, getInt32Buffer, textEncode, readInt64 } from "./tensorFlowHelpers";
+import { crc32c, maskCrc, textDecode, readInt64 } from "./tensorFlowHelpers";
 import { FeatureType } from "./tensorFlowBuilder";
 
 /**
@@ -74,8 +74,20 @@ export class TFRecordsReader {
         // Guard.expression(recordPos, (num) => num >= 0 && num < this.imageMessages.length);
         const message = this.imageMessages[recordPos];
         const feature = message.getContext().getFeatureMap().get(key);
-        const list = feature.getInt64List().array;
 
-        return list[0];
+        switch (type) {
+            case FeatureType.String:
+                return textDecode(feature.getBytesList().array[0][0]);
+            case FeatureType.Binary:
+                return feature.getBytesList().array[0][0];
+            case FeatureType.Int64:
+                return feature.getInt64List().array[0][0];
+            case FeatureType.Float:
+                return feature.getFloatList().array[0][0];
+            default:
+                break;
+        }
+
+        return null;
     }
 }

--- a/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
@@ -83,11 +83,8 @@ export class TFRecordsReader {
             case FeatureType.Int64:
                 return feature.getInt64List().array[0][0];
             case FeatureType.Float:
-                return feature.getFloatList().array[0][0];
             default:
-                break;
+                return feature.getFloatList().array[0][0];
         }
-
-        return null;
     }
 }

--- a/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
+++ b/src/providers/export/tensorFlowRecords/tensorFlowReader.ts
@@ -2,6 +2,7 @@ import Guard from "../../../common/guard";
 import { TFRecordsImageMessage, Features, Feature, FeatureList,
     BytesList, Int64List, FloatList } from "./tensorFlowRecordsProtoBuf_pb";
 import { crc32c, maskCrc, getInt64Buffer, getInt32Buffer, textEncode, readInt64 } from "./tensorFlowHelpers";
+import { FeatureType } from "./tensorFlowBuilder";
 
 /**
  * @name - TFRecords Read Class
@@ -61,5 +62,20 @@ export class TFRecordsReader {
      */
     public toArray(): object[] {
         return this.imageMessages.map((imageMessage) => imageMessage.toObject());
+    }
+
+    /**
+     * @recordPos - Record Position
+     * @key - Feature Key
+     * @type - Feature Type
+     * @description - Get a Int64 | Float | String | Binary value
+     */
+    public getFeature(recordPos: number, key: string, type: FeatureType): string | number | Uint8Array {
+        // Guard.expression(recordPos, (num) => num >= 0 && num < this.imageMessages.length);
+        const message = this.imageMessages[recordPos];
+        const feature = message.getContext().getFeatureMap().get(key);
+        const list = feature.getInt64List().array;
+
+        return list[0];
     }
 }

--- a/src/react/components/pages/editorPage/assetPreview.tsx
+++ b/src/react/components/pages/editorPage/assetPreview.tsx
@@ -28,6 +28,8 @@ interface IAssetPreviewState {
  */
 export default class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPreviewState> {
 
+    private tfRecordImage64: string;
+
     constructor(props, context) {
         super(props, context);
 
@@ -38,7 +40,7 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
         this.onAssetLoad = this.onAssetLoad.bind(this);
     }
 
-    public async render() {
+    public render() {
         const { loaded } = this.state;
         const { asset } = this.props;
         const { videoSettings } = this.props;
@@ -59,13 +61,19 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                     </video>
                 }
                 {asset.type === AssetType.TFRecord &&
-                    <img src={await this.getTFRecordBase64Image(asset)} onLoad={this.onAssetLoad} />
+                    <img src={this.tfRecordImage64} onLoad={this.onAssetLoad} />
                 }
                 {asset.type === AssetType.Unknown &&
                     <div>{strings.editorPage.assetError}</div>
                 }
             </div>
         );
+    }
+
+    public async componentDidMount() {
+        if (this.props.asset.type === AssetType.TFRecord) {
+            this.tfRecordImage64 = await this.getTFRecordBase64Image(this.props.asset);
+        }
     }
 
     private async getTFRecordBase64Image(asset: IAsset): Promise<string> {

--- a/src/react/components/pages/editorPage/assetPreview.tsx
+++ b/src/react/components/pages/editorPage/assetPreview.tsx
@@ -61,7 +61,9 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
                     </video>
                 }
                 {asset.type === AssetType.TFRecord &&
-                    <img src={this.tfRecordImage64} onLoad={this.onAssetLoad} />
+                    <div className="tfrecord-image" id={asset.id}>
+                        <img src={this.tfRecordImage64} onLoad={this.onAssetLoad} />
+                    </div>
                 }
                 {asset.type === AssetType.Unknown &&
                     <div>{strings.editorPage.assetError}</div>
@@ -73,6 +75,9 @@ export default class AssetPreview extends React.Component<IAssetPreviewProps, IA
     public async componentDidMount() {
         if (this.props.asset.type === AssetType.TFRecord) {
             this.tfRecordImage64 = await this.getTFRecordBase64Image(this.props.asset);
+            const tfRecordDiv = document.getElementById(this.props.asset.id) as HTMLDivElement;
+            const tfRecordImage = tfRecordDiv.getElementsByTagName("img")[0];
+            tfRecordImage.src = this.tfRecordImage64;
         }
     }
 

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -59,6 +59,8 @@ export class AssetService {
             case "mpg":
             case "wmv":
                 return AssetType.Video;
+            case "tfrecord":
+                return AssetType.TFRecord;
             default:
                 return AssetType.Unknown;
         }


### PR DESCRIPTION
This PR focus on importing .tfrecords asset file from any project / source connector and display the asset images in preview and editor pages.

Next PR will import full metadata info from tfrecords including regions and tags info.
