### PR TITLE
Small refactor of canvas and editor page

### DIFF
--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -2,7 +2,7 @@ import shortid from "shortid";
 import {
     AssetState, AssetType, IApplicationState, IAppSettings, IAsset, IAssetMetadata,
     IConnection, IExportFormat, IProject, ITag, StorageType, ISecurityToken,
-    EditorMode, IAppError, IProjectVideoSettings, AppError, ErrorCode, ITagMetadata,
+    EditorMode, IAppError, IProjectVideoSettings, AppError, ErrorCode,
     IPoint, IRegion, RegionType, IBoundingBox,
 } from "../models/applicationState";
 import { ExportAssetState } from "../providers/export/exportProvider";
@@ -101,10 +101,7 @@ export default class MockFactory {
      * Creates a mock region
      */
     public static createMockRegion(): IRegion {
-        const mockTag: ITagMetadata = {
-            name: "Tag 1",
-            properties: null,
-        };
+        const mockTag: ITag = MockFactory.createTestTag();
 
         const mockStartPoint: IPoint = {
             x: 1,

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -242,20 +242,9 @@ export interface ISize {
 export interface IRegion {
     id: string;
     type: RegionType;
-    tags: ITagMetadata[];
+    tags: ITag[];
     points?: IPoint[];
     boundingBox?: IBoundingBox;
-}
-
-/**
- * @name - Tag Metadata
- * @description - Defines the tag usage within a region
- * @member name - The tag name
- * @member properties - An object that defines addition metadata for this tag
- */
-export interface ITagMetadata {
-    name: string;
-    properties?: object;
 }
 
 /**

--- a/src/providers/export/azureCustomVision.test.ts
+++ b/src/providers/export/azureCustomVision.test.ts
@@ -132,7 +132,7 @@ describe("Azure Custom Vision Export Provider", () => {
                         id: shortid.generate(),
                         type: RegionType.Rectangle,
                         tags: [
-                            { name: testProject.tags[0].name },
+                            testProject.tags[0],
                         ],
                         boundingBox: {
                             left: 10,

--- a/src/providers/export/tensorFlowPascalVOC.test.ts
+++ b/src/providers/export/tensorFlowPascalVOC.test.ts
@@ -5,7 +5,7 @@ import { ExportAssetState } from "./exportProvider";
 import registerProviders from "../../registerProviders";
 import { ExportProviderFactory } from "./exportProviderFactory";
 import { IProject, IAssetMetadata, AssetState, IRegion, RegionType,
-         ITagMetadata, IPoint } from "../../models/applicationState";
+         ITag, IPoint } from "../../models/applicationState";
 import MockFactory from "../../common/mockFactory";
 import axios from "axios";
 
@@ -65,10 +65,7 @@ describe("TFPascalVOC Json Export Provider", () => {
         beforeEach(() => {
             const assetServiceMock = AssetService as jest.Mocked<typeof AssetService>;
             assetServiceMock.prototype.getAssetMetadata = jest.fn((asset) => {
-                const mockTag: ITagMetadata = {
-                    name: "Tag 1",
-                    properties: null,
-                };
+                const mockTag = MockFactory.createTestTag();
 
                 const mockStartPoint: IPoint = {
                     x: 1,

--- a/src/providers/export/tensorFlowRecords.test.ts
+++ b/src/providers/export/tensorFlowRecords.test.ts
@@ -5,7 +5,7 @@ import { ExportAssetState } from "./exportProvider";
 import registerProviders from "../../registerProviders";
 import { ExportProviderFactory } from "./exportProviderFactory";
 import { IProject, IAssetMetadata, AssetState, IRegion, RegionType,
-         ITagMetadata, IPoint } from "../../models/applicationState";
+         ITag, IPoint } from "../../models/applicationState";
 import MockFactory from "../../common/mockFactory";
 import axios, { AxiosResponse } from "axios";
 
@@ -59,10 +59,7 @@ describe("TFRecords Json Export Provider", () => {
         beforeEach(() => {
             const assetServiceMock = AssetService as jest.Mocked<typeof AssetService>;
             assetServiceMock.prototype.getAssetMetadata = jest.fn((asset) => {
-                const mockTag: ITagMetadata = {
-                    name: "Tag 1",
-                    properties: null,
-                };
+                const mockTag = MockFactory.createTestTag();
 
                 const mockStartPoint: IPoint = {
                     x: 1,

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -9,6 +9,7 @@ import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 
 jest.mock("vott-ct");
 import { CanvasTools } from "vott-ct";
+import Tag from "reactstrap/lib/Tag";
 describe("Editor Canvas", () => {
     let wrapper: ReactWrapper<ICanvasProps, {}, Canvas> = null;
     const onAssetMetadataChanged = jest.fn();
@@ -91,5 +92,21 @@ describe("Editor Canvas", () => {
         expect(wrapper.instance().state.selectedRegions.length).toEqual(2);
         expect(wrapper.instance().state.selectedRegions)
             .toMatchObject([MockFactory.createTestRegion("test1"), MockFactory.createTestRegion("test2")]);
+    });
+
+    it("onTagClicked", () => {
+        const canvas = wrapper.instance();
+        const testRegion1 = MockFactory.createTestRegion("test1");
+        const testRegion2 = MockFactory.createTestRegion("test2");
+        wrapper.prop("selectedAsset").regions.push(testRegion1);
+        wrapper.prop("selectedAsset").regions.push(testRegion2);
+        canvas.onRegionSelected("test1", false);
+        canvas.onRegionSelected("test2", true);
+
+        const newTag = MockFactory.createTestTag();
+        canvas.onTagClicked(newTag);
+        for (const region of wrapper.instance().state.selectedRegions) {
+            expect(region.tags.findIndex((tag) => tag === newTag)).toBeGreaterThanOrEqual(0);
+        }
     });
 });

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -201,7 +201,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
      * @param tag Tag to add or remove from region
      */
     private toggleTagOnRegion = (region: IRegion, tag: ITag) => {
-        region.tags = CanvasHelpers.toggleTag(region.tags, tag);
+        CanvasHelpers.toggleTag(region.tags, tag);
         this.editor.RM.updateTagsById(region.id, CanvasHelpers.getTagsDescriptor(region));
     }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -21,7 +21,6 @@ export interface ICanvasProps {
     onAssetMetadataChanged: (assetMetadata: IAssetMetadata) => void;
     editorMode: EditorMode;
     project: IProject;
-    onTagLocked?();
 }
 
 interface ICanvasState {
@@ -67,7 +66,6 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
         return (
             <div id="ct-zone" className={this.state.canvasEnabled ? "canvas-enabled" : "canvas-disabled"}>
-
                 {selectedAsset.asset.type === AssetType.Video &&
                     <Player ref={this.videoPlayer}
                         fluid={false} width={"100%"} height={"100%"}

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -1,0 +1,33 @@
+import CanvasHelpers from "./canvasHelpers";
+import MockFactory from "../../../../common/mockFactory";
+
+describe("Canvas Helpers", () => {
+    it("Adds a tag to list", () => {
+        const originalTags = MockFactory.createTestTags();
+        const newTag = MockFactory.createTestTag("New Tag");
+        const newTags = CanvasHelpers.toggleTag(
+            originalTags,
+            newTag
+        );
+        expect(newTags).toHaveLength(originalTags.length + 1);
+        expect(newTags[newTags.length - 1]).toEqual(newTag);
+    });
+
+    it("Removes a tag from list", () => {
+        const originalTags = MockFactory.createTestTags();
+        const newTags = CanvasHelpers.toggleTag(
+            originalTags,
+            originalTags[0]
+        );
+        expect(newTags).toHaveLength(originalTags.length - 1);
+        expect(newTags[0]).not.toEqual(originalTags[0]);
+    });
+
+    it("Creates region data from region", () => {
+        
+    });
+
+    it("Creates a tag descriptor from region", () => {
+
+    });
+});

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -1,7 +1,8 @@
 import CanvasHelpers from "./canvasHelpers";
 import MockFactory from "../../../../common/mockFactory";
-import { RegionType } from "../../../../models/applicationState";
-import { RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
+import { RegionType, IRegion } from "../../../../models/applicationState";
+import { RegionDataType, RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
+import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 
 describe("Canvas Helpers", () => {
     it("Adds a tag to list", () => {
@@ -28,10 +29,50 @@ describe("Canvas Helpers", () => {
         expect(tags[0]).not.toEqual(originalFirstTag);
     });
 
+    it("Gets correct region data", () => {
+        const expected = new RegionData(
+            0, 0, 100, 100, 
+            [
+                new Point2D(0,0),
+                new Point2D(1, 0),
+                new Point2D(1,1),
+                new Point2D(0,0)
+            ],
+            RegionDataType.Polygon
+        );
+        
+        const region: IRegion = {
+            id: "test",
+            boundingBox: {
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100
+            },
+            points: [
+                {
+                    x: 0, y: 0
+                },
+                {
+                    x: 1, y: 0
+                },
+                {
+                    x: 1, y: 1
+                },{
+                    x: 0, y: 0
+                },
+            ],
+            type: RegionType.Polygon,
+            tags: []
+        }
+        expect(CanvasHelpers.getRegionData(region)).toEqual(expected);
+    });
+
     it("Gets correct region data type", () => {
         expect(CanvasHelpers.regionTypeToType(RegionType.Rectangle)).toEqual(RegionDataType.Rect);
         expect(CanvasHelpers.regionTypeToType(RegionType.Polygon)).toEqual(RegionDataType.Polygon);
         expect(CanvasHelpers.regionTypeToType(RegionType.Point)).toEqual(RegionDataType.Point);
         expect(CanvasHelpers.regionTypeToType(RegionType.Polyline)).toEqual(RegionDataType.Polyline);
+        expect(CanvasHelpers.regionTypeToType(null)).toBeUndefined();
     });
 });

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -31,40 +31,40 @@ describe("Canvas Helpers", () => {
 
     it("Gets correct region data", () => {
         const expected = new RegionData(
-            0, 0, 100, 100, 
+            0, 0, 100, 100,
             [
-                new Point2D(0,0),
+                new Point2D(0, 0),
                 new Point2D(1, 0),
-                new Point2D(1,1),
-                new Point2D(0,0)
+                new Point2D(1, 1),
+                new Point2D(0, 0),
             ],
-            RegionDataType.Polygon
+            RegionDataType.Polygon,
         );
-        
+
         const region: IRegion = {
             id: "test",
             boundingBox: {
                 left: 0,
                 top: 0,
                 width: 100,
-                height: 100
+                height: 100,
             },
             points: [
                 {
-                    x: 0, y: 0
+                    x: 0, y: 0,
                 },
                 {
-                    x: 1, y: 0
+                    x: 1, y: 0,
                 },
                 {
-                    x: 1, y: 1
-                },{
-                    x: 0, y: 0
+                    x: 1, y: 1,
+                }, {
+                    x: 0, y: 0,
                 },
             ],
             type: RegionType.Polygon,
-            tags: []
-        }
+            tags: [],
+        };
         expect(CanvasHelpers.getRegionData(region)).toEqual(expected);
     });
 

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -4,23 +4,26 @@ import MockFactory from "../../../../common/mockFactory";
 describe("Canvas Helpers", () => {
     it("Adds a tag to list", () => {
         const originalTags = MockFactory.createTestTags();
+        const originalLength = originalTags.length;
         const newTag = MockFactory.createTestTag("New Tag");
         const newTags = CanvasHelpers.toggleTag(
             originalTags,
             newTag,
         );
-        expect(newTags).toHaveLength(originalTags.length + 1);
+        expect(newTags).toHaveLength(originalLength + 1);
         expect(newTags[newTags.length - 1]).toEqual(newTag);
     });
 
     it("Removes a tag from list", () => {
         const originalTags = MockFactory.createTestTags();
+        const originalLength = originalTags.length;
+        const originalFirstTag = originalTags[0];
         const newTags = CanvasHelpers.toggleTag(
             originalTags,
             originalTags[0],
         );
-        expect(newTags).toHaveLength(originalTags.length - 1);
-        expect(newTags[0]).not.toEqual(originalTags[0]);
+        expect(newTags).toHaveLength(originalLength - 1);
+        expect(newTags[0]).not.toEqual(originalFirstTag);
     });
 
     it("Creates region data from region", () => {

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -7,7 +7,7 @@ describe("Canvas Helpers", () => {
         const newTag = MockFactory.createTestTag("New Tag");
         const newTags = CanvasHelpers.toggleTag(
             originalTags,
-            newTag
+            newTag,
         );
         expect(newTags).toHaveLength(originalTags.length + 1);
         expect(newTags[newTags.length - 1]).toEqual(newTag);
@@ -17,17 +17,17 @@ describe("Canvas Helpers", () => {
         const originalTags = MockFactory.createTestTags();
         const newTags = CanvasHelpers.toggleTag(
             originalTags,
-            originalTags[0]
+            originalTags[0],
         );
         expect(newTags).toHaveLength(originalTags.length - 1);
         expect(newTags[0]).not.toEqual(originalTags[0]);
     });
 
     it("Creates region data from region", () => {
-        
+        expect(true).toBeTruthy();
     });
 
     it("Creates a tag descriptor from region", () => {
-
+        expect(true).toBeTruthy();
     });
 });

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -1,36 +1,37 @@
 import CanvasHelpers from "./canvasHelpers";
 import MockFactory from "../../../../common/mockFactory";
+import { RegionType } from "../../../../models/applicationState";
+import { RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 
 describe("Canvas Helpers", () => {
     it("Adds a tag to list", () => {
-        const originalTags = MockFactory.createTestTags();
-        const originalLength = originalTags.length;
+        const tags = MockFactory.createTestTags();
+        const originalLength = tags.length;
         const newTag = MockFactory.createTestTag("New Tag");
-        const newTags = CanvasHelpers.toggleTag(
-            originalTags,
+        CanvasHelpers.toggleTag(
+            tags,
             newTag,
         );
-        expect(newTags).toHaveLength(originalLength + 1);
-        expect(newTags[newTags.length - 1]).toEqual(newTag);
+        expect(tags).toHaveLength(originalLength + 1);
+        expect(tags[tags.length - 1]).toEqual(newTag);
     });
 
     it("Removes a tag from list", () => {
-        const originalTags = MockFactory.createTestTags();
-        const originalLength = originalTags.length;
-        const originalFirstTag = originalTags[0];
-        const newTags = CanvasHelpers.toggleTag(
-            originalTags,
-            originalTags[0],
+        const tags = MockFactory.createTestTags();
+        const originalLength = tags.length;
+        const originalFirstTag = tags[0];
+        CanvasHelpers.toggleTag(
+            tags,
+            tags[0],
         );
-        expect(newTags).toHaveLength(originalLength - 1);
-        expect(newTags[0]).not.toEqual(originalFirstTag);
+        expect(tags).toHaveLength(originalLength - 1);
+        expect(tags[0]).not.toEqual(originalFirstTag);
     });
 
-    it("Creates region data from region", () => {
-        expect(true).toBeTruthy();
-    });
-
-    it("Creates a tag descriptor from region", () => {
-        expect(true).toBeTruthy();
+    it("Gets correct region data type", () => {
+        expect(CanvasHelpers.regionTypeToType(RegionType.Rectangle)).toEqual(RegionDataType.Rect);
+        expect(CanvasHelpers.regionTypeToType(RegionType.Polygon)).toEqual(RegionDataType.Polygon);
+        expect(CanvasHelpers.regionTypeToType(RegionType.Point)).toEqual(RegionDataType.Point);
+        expect(CanvasHelpers.regionTypeToType(RegionType.Polyline)).toEqual(RegionDataType.Polyline);
     });
 });

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -28,7 +28,7 @@ export default class CanvasHelpers {
 
     /**
      * Get RegionData (CanvasTools) from IRegion
-     * @param region IRegion from Canvas
+     * @param region IRegion from Canvas component
      */
     public static getRegionData(region: IRegion): RegionData {
         return new RegionData(region.boundingBox.left,

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -4,9 +4,18 @@ import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/Regi
 import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
 
+/**
+ * Static functions to assist in operations within Canvas component
+ */
 export default class CanvasHelpers {
 
-    public static toggleTag(tags: ITag[], tag: ITag): ITag[] {
+    /**
+     * Adds tag to array if it does not contain the tag,
+     * removes tag if already contained. Performs operations in place
+     * @param tags Array of tags
+     * @param tag Tag to toggle
+     */
+    public static toggleTag(tags: ITag[], tag: ITag): void {
         const tagIndex = tags.findIndex((existingTag) => existingTag.name === tag.name);
         if (tagIndex === -1) {
             // Tag isn't found within region tags, add it
@@ -15,9 +24,12 @@ export default class CanvasHelpers {
             // Tag is within region tags, remove it
             tags.splice(tagIndex, 1);
         }
-        return tags;
     }
 
+    /**
+     * Get RegionData (CanvasTools) from IRegion
+     * @param region IRegion from Canvas
+     */
     public static getRegionData(region: IRegion): RegionData {
         return new RegionData(region.boundingBox.left,
             region.boundingBox.top,
@@ -28,11 +40,18 @@ export default class CanvasHelpers {
             this.regionTypeToType(region.type));
     }
 
+    /**
+     * Create TagsDescriptor (CanvasTools) from IRegion
+     * @param region IRegion from Canvas
+     */
     public static getTagsDescriptor(region: IRegion): TagsDescriptor {
         return new TagsDescriptor(region.tags.map((tag) => new Tag(tag.name, tag.color)));
     }
 
-    private static regionTypeToType = (regionType: RegionType) => {
+    /**
+     * Gets RegionDataType (CanvasTools) from RegionType
+     */
+    public static regionTypeToType = (regionType: RegionType) => {
         let type;
         switch (regionType) {
             case RegionType.Rectangle:

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -1,0 +1,55 @@
+import { ITag, IRegion, RegionType } from "../../../../models/applicationState";
+import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
+import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
+import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
+import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
+
+export default class CanvasHelpers {
+
+    public static toggleTag(tags: ITag[], tag: ITag): ITag[] {
+        const tagIndex = tags.findIndex((existingTag) => existingTag.name === tag.name);
+        if (tagIndex === -1) {
+            // Tag isn't found within region tags, add it
+            tags.push(tag);
+        } else {
+            // Tag is within region tags, remove it
+            tags.splice(tagIndex, 1);
+        }
+        return tags;
+    }
+
+    public static getRegionData(region: IRegion): RegionData {
+        return new RegionData(region.boundingBox.left,
+            region.boundingBox.top,
+            region.boundingBox.width,
+            region.boundingBox.height,
+            region.points.map((point) =>
+                new Point2D(point.x, point.y)),
+            this.regionTypeToType(region.type));
+    }
+
+    public static getTagsDescriptor(region: IRegion): TagsDescriptor {
+        return new TagsDescriptor(region.tags.map((tag) => new Tag(tag.name, tag.color)));
+    }
+
+    private static regionTypeToType = (regionType: RegionType) => {
+        let type;
+        switch (regionType) {
+            case RegionType.Rectangle:
+                type = RegionDataType.Rect;
+                break;
+            case RegionType.Polygon:
+                type = RegionDataType.Polygon;
+                break;
+            case RegionType.Point:
+                type = RegionDataType.Point;
+                break;
+            case RegionType.Polyline:
+                type = RegionDataType.Polyline;
+                break;
+            default:
+                break;
+        }
+        return type;
+    }
+}

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -6,7 +6,7 @@ import { AnyAction, Store } from "redux";
 import MockFactory from "../../../../common/mockFactory";
 import {
     IApplicationState, IAssetMetadata, IProject,
-    EditorMode, IAsset, AssetState,
+    EditorMode, IAsset, AssetState, IRegion,
 } from "../../../../models/applicationState";
 import { AssetProviderFactory } from "../../../../providers/storage/assetProviderFactory";
 import createReduxStore from "../../../../redux/store/store";
@@ -41,6 +41,28 @@ function createComponent(store, props: IEditorPageProps): ReactWrapper<IEditorPa
 
 function getState(wrapper): IEditorPageState {
     return wrapper.find(EditorPage).childAt(0).state() as IEditorPageState;
+}
+
+function getMockAssetMetadata(testAssets, assetIndex= 0): IAssetMetadata {
+    const mockRegion = MockFactory.createMockRegion();
+    return {
+        asset: {
+            ...testAssets[assetIndex],
+            state: AssetState.Visited,
+        },
+        regions: [
+            {
+                ...mockRegion,
+                tags: [
+                    {
+                        ...mockRegion.tags[0],
+                        color: expect.stringMatching(/^#(?:[0-9a-f]{3}){1,2}$/i),
+                    },
+                ],
+            },
+        ],
+        timestamp: null,
+    };
 }
 
 describe("Editor Page Component", () => {
@@ -119,19 +141,12 @@ describe("Editor Page Component", () => {
             name: testProject.name,
         };
 
-        const expectedAssetMetadtata: IAssetMetadata = {
-            asset: {
-                ...testAssets[0],
-                state: AssetState.Visited,
-            },
-            regions: [MockFactory.createMockRegion()],
-            timestamp: null,
-        };
+        const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets);
 
         setImmediate(() => {
             expect(editorPage.props().project).toEqual(expect.objectContaining(partialProject));
             expect(editorPage.state().assets.length).toEqual(testAssets.length);
-            expect(editorPage.state().selectedAsset).toEqual(expectedAssetMetadtata);
+            expect(editorPage.state().selectedAsset).toMatchObject(expectedAssetMetadtata);
             done();
         });
     });
@@ -168,14 +183,7 @@ describe("Editor Page Component", () => {
             name: testProject.name,
         };
 
-        const expectedAssetMetadtata: IAssetMetadata = {
-            asset: {
-                ...testAssets[0],
-                state: AssetState.Visited,
-            },
-            regions: [MockFactory.createMockRegion()],
-            timestamp: null,
-        };
+        const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets);
 
         setImmediate(() => {
             expect(loadAssetMetadataSpy).toBeCalledWith(expect.objectContaining(partialProject), defaultAsset);
@@ -230,16 +238,9 @@ describe("Editor Page Component", () => {
 
             wrapper.update();
 
-            const expectedAssetMetadtata: IAssetMetadata = {
-                asset: {
-                    ...testAssets[1],
-                    state: AssetState.Visited,
-                },
-                regions: [MockFactory.createMockRegion()],
-                timestamp: null,
-            };
+            const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets, 1);
 
-            expect(getState(wrapper).selectedAsset).toEqual(expectedAssetMetadtata);
+            expect(getState(wrapper).selectedAsset).toMatchObject(expectedAssetMetadtata);
         });
 
         it("selects the previous asset when clicking the 'Previous Asset' button in the toolbar", async () => {
@@ -249,16 +250,9 @@ describe("Editor Page Component", () => {
 
             wrapper.update();
 
-            const expectedAssetMetadtata: IAssetMetadata = {
-                asset: {
-                    ...testAssets[1],
-                    state: AssetState.Visited,
-                },
-                regions: [MockFactory.createMockRegion()],
-                timestamp: null,
-            };
+            const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets, 1);
 
-            expect(getState(wrapper).selectedAsset).toEqual(expectedAssetMetadtata);
+            expect(getState(wrapper).selectedAsset).toMatchObject(expectedAssetMetadtata);
         });
     });
 
@@ -329,7 +323,7 @@ describe("Editor Page Component", () => {
             setImmediate(() => {
                 (editorPage.instance() as EditorPage)
                     .handleTagHotKey({ ctrlKey: true, key: keyPressed.toString() } as KeyboardEvent);
-                expect(spy).toBeCalledWith({ name: testProject.tags[keyPressed - 1].name });
+                expect(spy).toBeCalledWith(testProject.tags[keyPressed - 1]);
             });
         });
     });

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -56,7 +56,7 @@ function getMockAssetMetadata(testAssets, assetIndex= 0): IAssetMetadata {
                 tags: [
                     {
                         ...mockRegion.tags[0],
-                        color: expect.stringMatching(/^#(?:[0-9a-f]{3}){1,2}$/i),
+                        color: expect.stringMatching(/^#[0-9a-f]{3,6}$/i),
                     },
                 ],
             },

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -122,7 +122,7 @@ describe("Editor Page Component", () => {
         const store = createStore(testProject, true);
         const props = MockFactory.editorPageProps(testProject.id);
 
-        videoPlayerPausedMock = Player as jest.Mocked<typeof Player>;
+        videoPlayerPausedMock = Player;
         videoPlayerPausedMock.prototype.subscribeToStateChange = jest.fn((callback) => {
             // Set up some state that is unpaused
             const state = {
@@ -134,7 +134,7 @@ describe("Editor Page Component", () => {
         });
 
         const wrapper = createComponent(store, props);
-        const editorPage = wrapper.find(EditorPage).childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
+        const editorPage = wrapper.find(EditorPage).childAt(0);
 
         const partialProject = {
             id: testProject.id,
@@ -160,7 +160,7 @@ describe("Editor Page Component", () => {
         const store = createStore(testProject, true);
         const props = MockFactory.editorPageProps(testProject.id);
 
-        videoPlayerUnpausedMock = Player as jest.Mocked<typeof Player>;
+        videoPlayerUnpausedMock = Player;
         videoPlayerUnpausedMock.prototype.subscribeToStateChange = jest.fn((callback) => {
             // Set up some state that is unpaused
             const state = {
@@ -213,7 +213,7 @@ describe("Editor Page Component", () => {
             await MockFactory.waitForCondition(() => {
                 const editorPage = wrapper
                     .find(EditorPage)
-                    .childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
+                    .childAt(0);
 
                 return !!editorPage.state().selectedAsset;
             });

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -8,7 +8,7 @@ import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import HtmlFileReader from "../../../../common/htmlFileReader";
 import {
     AssetState, EditorMode, IApplicationState, IAsset,
-    IAssetMetadata, IProject, ITagMetadata, IAssetVideoSettings,
+    IAssetMetadata, IProject, IAssetVideoSettings, ITag,
 } from "../../../../models/applicationState";
 import { IToolbarItemRegistration, ToolbarItemFactory } from "../../../../providers/toolbar/toolbarItemFactory";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
@@ -165,7 +165,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
      * Called when a tag from footer is clicked
      * @param tag Tag clicked
      */
-    public onTagClicked(tag: ITagMetadata) {
+    public onTagClicked(tag: ITag) {
         const selectedAsset = this.state.selectedAsset;
         if (this.canvas.current.state.selectedRegions && this.canvas.current.state.selectedRegions.length) {
             const selectedRegions = this.canvas.current.state.selectedRegions;
@@ -202,14 +202,14 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         if (isNaN(key)) {
             return;
         }
-        let tag: ITagMetadata;
+        let tag: ITag;
         const tags = this.props.project.tags;
         if (key === 0) {
             if (tags.length >= 10) {
-                tag = { name: tags[9].name };
+                tag = tags[9];
             }
         } else if (tags.length >= key) {
-            tag = { name: tags[key - 1].name };
+            tag = tags[key - 1];
         }
         this.onTagClicked(tag);
     }


### PR DESCRIPTION
Preparatory to cut/copy/paste effort. Trying to make canvas a little easier to work with, but didn't want the PR to be too big. Main changes are:
- Replace `ITagMetadata` with `ITag`
- Break up large functions in canvas to smaller, re-usable functions