### PR TITLE
Added v2 complexity report scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ secrets.sh
 # ide
 .idea
 
-# compile
-js-src/
-plato-report/
+# complexity reports
+es6-src/
+report/

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "test": "react-scripts test --env=jsdom --silent",
         "test:ci": "cross-env CI=true npm run test",
         "test:coverage": "npm run test -- --coverage",
-        "plato": "tsc --noEmit false --outDir js-src && plato -r -d plato-report js-src",
+        "plato": "scripts/generate-report.sh",
         "postinstall": "electron-builder install-app-deps",
         "predebug": "npm run build && npm run webpack:dev"
     },
@@ -88,7 +88,6 @@
         "jest-enzyme": "^7.0.1",
         "jquery": "^3.3.1",
         "node-sass": "^4.10.0",
-        "plato": "^1.7.0",
         "popper.js": "^1.14.6",
         "react-jsonschema-form": "^1.0.6",
         "react-modal": "^3.6.1",

--- a/scripts/complexity-analysis.js
+++ b/scripts/complexity-analysis.js
@@ -1,0 +1,50 @@
+
+const plato = require('es6-plato');
+
+// parse command line args
+const optionDefinitions = [
+    { name: 'src', type: String, defaultValue: './es6-src/**' },
+    { name: 'output', type: String, defaultValue: './report' }
+]
+const commandLineArgs = require('command-line-args');
+const options = commandLineArgs(optionDefinitions)
+
+// close(ish) eslint config for ES6 + React
+let lintRules = {
+    extends: [
+        'eslint:recommended',
+        'plugin:react/recommended'
+    ],
+    plugins: [
+        'react'
+    ],
+    env: {
+        es6: true,
+        browser: true,
+        serviceworker: true
+    },
+    parserOptions: {
+        'ecmaVersion': 6,
+        'sourceType': 'module',
+        'ecmaFeatures': {
+            'jsx': true
+        }
+    },
+    rules: {
+        quotes: [2, 'double']
+    }
+};
+
+// exclude all tests, toolbar/mockFactory and localization
+let exclude = /\.test|registerToolbar|en-us|es-cl|mockFactory/;
+let complexityRules = {};
+
+let platoArgs = {
+    title: 'VoTT v2 Complexity Analysis',
+    exclude: exclude,
+    eslint: lintRules,
+    complexity: complexityRules
+};
+
+console.info(`Running complexity analysis on \`${options.src}\`, writing results to \`${options.output}\`...`);
+plato.inspect(options.src, options.output, platoArgs);

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# -e: immediately exit if any command has a non-zero exit status
+# -o: prevents errors in a pipeline from being masked
+
+# these are just needed for the reports; just install ad-hoc and don't save to package.json
+npm install es6-plato eslint-plugin-react command-line-args --no-save
+
+BASEDIR=$(dirname "$0")
+ES6_SRC=./es6-src
+REPORT_DIR=./report
+
+# we can't do complexity analysis on TypeScript directly; transpile to ES6
+rm -rf ${ES6_SRC}
+tsc --noEmit false --outDir ${ES6_SRC}
+
+node ${BASEDIR}/complexity-analysis.js --src ${ES6_SRC} --output ${REPORT_DIR}


### PR DESCRIPTION
- Moved from `plato` --> `es6-plato`
- Running the tool (either one...) is easier as a script, using the module/API directly
- Added shell script for managing transpilation from TS --> ES6 and running report generation easily from CI
- Should work w/ existing CI scripts; still need to do work to upload this to blob to view history over time

#AB17036

![complexity](https://user-images.githubusercontent.com/4165265/52508607-0e8bfa00-2baa-11e9-8790-6297bcadd21f.png)
