### PR TITLE
Only hook video state change on non-preview assets AB#17076

### DIFF
--- a/src/react/components/common/assetPreview/videoAsset.test.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.test.tsx
@@ -55,6 +55,18 @@ describe("Video Asset Component", () => {
         expect(wrapper.state().loaded).toBe(false);
     });
 
+    it("does not subscribe to state change callback when autoPlay is false", () => {
+        const testProps: IVideoAssetProps = { ...defaultProps,
+            autoPlay: false,
+        };
+        wrapper = createComponent(testProps);
+        mockLoaded();
+
+        const newAsset = MockFactory.createVideoTestAsset("new-video-asset");
+        wrapper.setProps({ asset: newAsset });
+        expect(videoPlayerMock.prototype.subscribeToStateChange).not.toBeCalled();
+    });
+
     it("seeks the video player to the spcified timestamp when timestamp changes", () => {
         const expectedTime = 10.2;
         wrapper = createComponent();

--- a/src/react/components/common/assetPreview/videoAsset.test.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.test.tsx
@@ -16,7 +16,7 @@ describe("Video Asset Component", () => {
     const onChildSelectedHandler = jest.fn();
     const defaultProps: IVideoAssetProps = {
         asset: MockFactory.createVideoTestAsset("test-video"),
-        autoPlay: false,
+        autoPlay: true,
         timestamp: 0,
         onLoaded: onLoadedHandler,
         onActivated: onActivatedHandler,

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -117,7 +117,12 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     }
 
     public componentDidMount() {
-        this.videoPlayer.current.subscribeToStateChange(this.onVideoStateChange);
+        if (this.props.autoPlay) {
+            // We only need to subscribe to state change notificeations if autoPlay
+            // is true, otherwise the video is simply a preview on the side bar that
+            // doesn't change
+            this.videoPlayer.current.subscribeToStateChange(this.onVideoStateChange);
+        }
     }
 
     public componentDidUpdate(prevProps: Readonly<IVideoAssetProps>) {


### PR DESCRIPTION
We're currently running unnecessary code for every video in the side bar by hooking the video state change callback and going through all the logic there. Only hook this callback if autoPlay is true.