### PR TITLE
Fixes previous/next buttons to navigate between assets

### DIFF
--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -104,29 +104,29 @@ export default class MockFactory {
 
     /**
      * Creates a child videoFrame asset from a parent video asset
-     * @param parentAsset The parent video asset
+     * @param rootAsset The parent video asset
      * @param timestamp The timestamp to generate child asset
      */
-    public static createChildVideoAsset(parentAsset: IAsset, timestamp: number): IAsset {
-        const childPath = `${parentAsset.path}#t=${timestamp}`;
+    public static createChildVideoAsset(rootAsset: IAsset, timestamp: number): IAsset {
+        const childPath = `${rootAsset.path}#t=${timestamp}`;
         const childAsset = AssetService.createAssetFromFilePath(childPath);
         childAsset.type = AssetType.VideoFrame;
         childAsset.state = AssetState.Tagged;
-        childAsset.parent = parentAsset;
+        childAsset.parent = rootAsset;
         childAsset.timestamp = timestamp;
-        childAsset.size = { ...parentAsset.size };
+        childAsset.size = { ...rootAsset.size };
 
         return childAsset;
     }
 
     /**
      * Creates an array of child video frame assets from a parent video asset
-     * @param parentAsset The parent video asset
+     * @param rootAsset The parent video asset
      * @param count The number of child assets to create (default 10)
      */
-    public static createChildVideoAssets(parentAsset: IAsset, count: number = 10): IAsset[] {
+    public static createChildVideoAssets(rootAsset: IAsset, count: number = 10): IAsset[] {
         return [...Array(count).keys()].map((index) => {
-            return this.createChildVideoAsset(parentAsset, index);
+            return this.createChildVideoAsset(rootAsset, index);
         });
     }
 

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -172,11 +172,7 @@ export default class MockFactory {
     public static createTestAssets(count: number = 10, startIndex: number = 1): IAsset[] {
         const assets: IAsset[] = [];
         for (let i = startIndex; i < (count + startIndex); i++) {
-            const newAsset = (i % 2 === 1)
-                ? MockFactory.createVideoTestAsset(i.toString())
-                : MockFactory.createTestAsset(i.toString());
-
-            assets.push(newAsset);
+            assets.push(MockFactory.createTestAsset(i.toString()));
         }
 
         return assets;

--- a/src/react/components/common/assetPreview/assetPreview.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.tsx
@@ -71,7 +71,7 @@ export class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPrev
     public render() {
         const { loaded } = this.state;
         const { asset, childAssets, autoPlay } = this.props;
-        const parentAsset = asset.parent || asset;
+        const rootAsset = asset.parent || asset;
 
         return (
             <div className="asset-preview">
@@ -81,14 +81,14 @@ export class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPrev
                     </div>
                 }
                 {asset.type === AssetType.Image &&
-                    <ImageAsset asset={parentAsset}
+                    <ImageAsset asset={rootAsset}
                         additionalSettings={this.props.additionalSettings}
                         onLoaded={this.onAssetLoad}
                         onActivated={this.props.onActivated}
                         onDeactivated={this.props.onDeactivated} />
                 }
                 {(asset.type === AssetType.Video || asset.type === AssetType.VideoFrame) &&
-                    <VideoAsset asset={parentAsset}
+                    <VideoAsset asset={rootAsset}
                         additionalSettings={this.props.additionalSettings}
                         childAssets={childAssets}
                         timestamp={asset.timestamp}

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -257,12 +257,12 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
      */
     private raiseChildAssetSelected = (state: Readonly<IVideoPlayerState>) => {
         if (this.props.onChildAssetSelected) {
-            const parentAsset = this.props.asset.parent || this.props.asset;
-            const childPath = `${parentAsset.path}#t=${state.currentTime}`;
+            const rootAsset = this.props.asset.parent || this.props.asset;
+            const childPath = `${rootAsset.path}#t=${state.currentTime}`;
             const childAsset = AssetService.createAssetFromFilePath(childPath);
             childAsset.state = AssetState.Visited;
             childAsset.type = AssetType.VideoFrame;
-            childAsset.parent = parentAsset;
+            childAsset.parent = rootAsset;
             childAsset.timestamp = state.currentTime;
             childAsset.size = { ...this.props.asset.size };
 

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -234,8 +234,8 @@ describe("Editor Page Component", () => {
             regions: editedImageAsset.regions,
         });
 
-        const matchingParentAsset = editorPage.state().assets.find((asset) => asset.id === imageAsset.id);
-        expect(matchingParentAsset.state).toEqual(AssetState.Tagged);
+        const matchingRootAsset = editorPage.state().assets.find((asset) => asset.id === imageAsset.id);
+        expect(matchingRootAsset.state).toEqual(AssetState.Tagged);
     });
 
     describe("Editing Video Assets", () => {
@@ -306,8 +306,8 @@ describe("Editor Page Component", () => {
             // Child asset is updated
             expect(saveMock.mock.calls[1][0]).toEqual(editedVideoFrame);
 
-            const matchingParentAsset = editorPage.state().assets.find((asset) => asset.id === videoAsset.id);
-            expect(matchingParentAsset.state).toEqual(AssetState.Tagged);
+            const matchingRootAsset = editorPage.state().assets.find((asset) => asset.id === videoAsset.id);
+            expect(matchingRootAsset.state).toEqual(AssetState.Tagged);
         });
     });
     describe("Basic toolbar test", () => {

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -269,7 +269,7 @@ describe("Editor Page Component", () => {
             });
         });
 
-        it("When a VideoFrame is updated the parent asset is also updated", async () => {
+        it("When a VideoFrame is updated the root asset is also updated", async () => {
             const getAssetMetadataMock = assetServiceMock.prototype.getAssetMetadata as jest.Mock;
             getAssetMetadataMock.mockImplementationOnce(() => Promise.resolve({
                 asset: { ...videoAsset },
@@ -289,7 +289,7 @@ describe("Editor Page Component", () => {
 
             const editorPage = wrapper.find(EditorPage).childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
 
-            const expectedParentVideoMetadata: IAssetMetadata = {
+            const expectedRootVideoMetadata: IAssetMetadata = {
                 asset: {
                     ...videoAsset,
                     state: AssetState.Tagged,
@@ -297,11 +297,11 @@ describe("Editor Page Component", () => {
                 regions: [],
             };
 
-            // Called 2 times, one for parent and once for child.
+            // Called 2 times, once for root and once for child.
             expect(saveMock).toBeCalledTimes(2);
 
-            // Parent asset is updated
-            expect(saveMock.mock.calls[0][0]).toEqual(expectedParentVideoMetadata);
+            // Root asset is updated
+            expect(saveMock.mock.calls[0][0]).toEqual(expectedRootVideoMetadata);
 
             // Child asset is updated
             expect(saveMock.mock.calls[1][0]).toEqual(editedVideoFrame);

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -257,7 +257,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         }
 
         // Update parent asset if not already in the "Tagged" state
-        if (parentAsset.id !== assetMetadata.asset.id) {
+        if (parentAsset.id === assetMetadata.asset.id) {
+            parentAsset.state = assetMetadata.asset.state;
+        } else {
             const parentAssetMetadata = await this.props.actions.loadAssetMetadata(this.props.project, parentAsset);
 
             if (parentAssetMetadata.asset.state !== AssetState.Tagged) {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -262,7 +262,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         }
 
         // Update root asset if not already in the "Tagged" state
-        // This is primarily used in the case where a Video Fram is being edited.
+        // This is primarily used in the case where a Video Frame is being edited.
         // We want to ensure that in this case the root video asset state is accuratly
         // updated to match that state of the asset.
         if (rootAsset.id === assetMetadata.asset.id) {
@@ -346,14 +346,14 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     /**
      * Navigates to the previous / next root asset on the sidebar
-     * @param index Number specifiying asset navigation
+     * @param direction Number specifying asset navigation
      */
-    private goToRootAsset = async (index: number) => {
+    private goToRootAsset = async (direction: number) => {
         const selectedRootAsset = this.state.selectedAsset.asset.parent || this.state.selectedAsset.asset;
         const currentIndex = this.state.assets
             .findIndex((asset) => asset.id === selectedRootAsset.id);
 
-        if (index > 0) {
+        if (direction > 0) {
             await this.selectAsset(this.state.assets[Math.min(this.state.assets.length - 1, currentIndex + 1)]);
         } else {
             await this.selectAsset(this.state.assets[Math.max(0, currentIndex - 1)]);

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -239,7 +239,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         }
     }
 
-    private isChildAssetType = (asset: IAsset): boolean => {
+    private isTaggableAssetType = (asset: IAsset): boolean => {
         return asset.type === AssetType.Image || asset.type === AssetType.VideoFrame;
     }
 
@@ -250,7 +250,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
     private onAssetMetadataChanged = async (assetMetadata: IAssetMetadata): Promise<void> => {
         const parentAsset = { ...(assetMetadata.asset.parent || assetMetadata.asset) };
 
-        if (this.isChildAssetType(assetMetadata.asset)) {
+        if (this.isTaggableAssetType(assetMetadata.asset)) {
             assetMetadata.asset.state = assetMetadata.regions.length > 0 ? AssetState.Tagged : AssetState.Visited;
         } else if (assetMetadata.asset.state === AssetState.NotVisited) {
             assetMetadata.asset.state = AssetState.Visited;

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -21,6 +21,7 @@ export interface IEditorSideBarProps {
  */
 export interface IEditorSideBarState {
     selectedAsset: IAsset;
+    scrollToIndex: number;
 }
 
 /**
@@ -35,6 +36,9 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
 
         this.state = {
             selectedAsset: this.props.selectedAsset,
+            scrollToIndex: this.props.selectedAsset
+                ? this.props.assets.findIndex((asset) => asset.id === this.props.selectedAsset.id)
+                : 0,
         };
 
         this.rowRenderer = this.rowRenderer.bind(this);
@@ -55,6 +59,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                             rowCount={this.props.assets.length}
                             rowHeight={233}
                             rowRenderer={this.rowRenderer}
+                            scrollToIndex={this.state.scrollToIndex}
                             overscanRowCount={2}
                         />
                     )}
@@ -77,6 +82,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private selectAsset(asset: IAsset) {
         this.setState({
             selectedAsset: asset,
+            scrollToIndex: this.props.assets.findIndex((asset) => asset.id === this.props.selectedAsset.id),
         }, () => {
             this.listRef.current.forceUpdateGrid();
         });

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -21,7 +21,6 @@ export interface IEditorSideBarProps {
  */
 export interface IEditorSideBarState {
     selectedAsset: IAsset;
-    scrollToIndex: number;
 }
 
 /**
@@ -36,9 +35,6 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
 
         this.state = {
             selectedAsset: this.props.selectedAsset,
-            scrollToIndex: this.props.selectedAsset
-                ? this.props.assets.findIndex((asset) => asset.id === this.props.selectedAsset.id)
-                : 0,
         };
 
         this.rowRenderer = this.rowRenderer.bind(this);
@@ -59,7 +55,6 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                             rowCount={this.props.assets.length}
                             rowHeight={233}
                             rowRenderer={this.rowRenderer}
-                            scrollToIndex={this.state.scrollToIndex}
                             overscanRowCount={2}
                         />
                     )}
@@ -82,7 +77,6 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private selectAsset(asset: IAsset) {
         this.setState({
             selectedAsset: asset,
-            scrollToIndex: this.props.assets.findIndex((asset) => asset.id === this.props.selectedAsset.id),
         }, () => {
             this.listRef.current.forceUpdateGrid();
         });

--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -91,7 +91,8 @@ describe("Asset Service", () => {
 
                     return JSON.stringify(assetMetadata, null, 4);
                 }),
-                writeText: jest.fn((filePath, contents) => true),
+                writeText: jest.fn(() => Promise.resolve()),
+                deleteFile: jest.fn(() => Promise.resolve()),
             };
 
             AssetProviderFactory.create = jest.fn(() => assetProviderMock);
@@ -154,6 +155,9 @@ describe("Asset Service", () => {
             const result = await assetService.save(assetMetadata);
 
             expect(storageProviderMock.writeText).not.toBeCalled();
+            expect(storageProviderMock.deleteFile).toBeCalledWith(
+                `${assetMetadata.asset.id}${constants.assetMetadataFileExtension}`,
+            );
             expect(result).toBe(assetMetadata);
         });
 

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -158,11 +158,14 @@ export class AssetService {
     public async save(metadata: IAssetMetadata): Promise<IAssetMetadata> {
         Guard.null(metadata);
 
+        const fileName = `${metadata.asset.id}${constants.assetMetadataFileExtension}`;
+
         // Only save asset metadata if asset is in a tagged state
         // Otherwise primary asset information is already persisted in the project file.
         if (metadata.asset.state === AssetState.Tagged) {
-            const fileName = `${metadata.asset.id}${constants.assetMetadataFileExtension}`;
             await this.storageProvider.writeText(fileName, JSON.stringify(metadata, null, 4));
+        } else {
+            await this.storageProvider.deleteFile(fileName);
         }
 
         return metadata;

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -136,18 +136,18 @@ export class AssetService {
 
     /**
      * Get a list of child assets associated with the current asset
-     * @param parentAsset The parent asset to search
+     * @param rootAsset The parent asset to search
      */
-    public getChildAssets(parentAsset: IAsset): IAsset[] {
-        Guard.null(parentAsset);
+    public getChildAssets(rootAsset: IAsset): IAsset[] {
+        Guard.null(rootAsset);
 
-        if (parentAsset.type !== AssetType.Video) {
+        if (rootAsset.type !== AssetType.Video) {
             return [];
         }
 
         return _
             .values(this.project.assets)
-            .filter((asset) => asset.parent && asset.parent.id === parentAsset.id)
+            .filter((asset) => asset.parent && asset.parent.id === rootAsset.id)
             .sort((a, b) => a.timestamp - b.timestamp);
     }
 


### PR DESCRIPTION
- Fixes bug where editor page was attempting to set the selectedAsset in the sidebar to a non-root asset
- Renamed `parentAsset` to `rootAsset` to make this more clear in event handlers