### PR TITLE
EditorPage does not have correct state when navigating directly via URL- AB#17079

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -127,6 +127,24 @@ describe("Editor Page Component", () => {
         expect(editorPage.prop("project")).toEqual(testProject);
     });
 
+    it("Updates state from props changes if project is null at creation", async () => {
+        const testProject = MockFactory.createTestProject("TestProject");
+        const store = createStore(testProject, false);
+        const props = MockFactory.editorPageProps(testProject.id);
+
+        // Simulate navigation directly via a null project
+        props.project = null;
+
+        const wrapper = createComponent(store, props);
+        const editorPage = wrapper.find(EditorPage).childAt(0);
+        expect(getState(wrapper).project).toBeNull();
+
+        editorPage.props().project = testProject;
+        await MockFactory.flushUi();
+        expect(editorPage.props().project).toEqual(testProject);
+        expect(getState(wrapper).project).toEqual(testProject);
+    });
+
     it("Loads and merges project assets with asset provider assets when state changes", async () => {
         const projectAssets = MockFactory.createTestAssets(10, 10);
         const testProject = MockFactory.createTestProject("TestProject");

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -102,6 +102,16 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         if (this.props.project && this.state.assets.length === 0) {
             await this.loadProjectAssets();
         }
+
+        // Navigating directly to the page via URL (ie, http://vott/projects/a1b2c3dEf/edit) sets the default state
+        // before props has been set, this updates the project and additional settings to be valid once props are
+        // retrieved.
+        if (!this.state.project && this.props.project) {
+            this.setState({
+                project: this.props.project,
+                additionalSettings: {videoSettings: (this.props.project) ? this.props.project.videoSettings : null},
+            });
+        }
     }
 
     public render() {


### PR DESCRIPTION
When navigating directly to a project edit page via URL, the initial state is invalid, and is not updated when the correct data is retrieved, and this fixes that.