### PR TITLE
Fix Asset detection from path

### DIFF
--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -57,6 +57,12 @@ describe("Asset Service", () => {
             expect(asset.type).toEqual(AssetType.Video);
         });
 
+        it("detects a video asset by common file extension", () => {
+            const path = "C:\\dir1\\dir2\\asset1.mp4#t=5";
+            const asset = AssetService.createAssetFromFilePath(path);
+            expect(asset.type).toEqual(AssetType.Video);
+        });
+
         it("detects a tfrecord asset by common file extension", () => {
             const path = "C:\\dir1\\dir2\\asset1.tfrecord";
             const asset = AssetService.createAssetFromFilePath(path);
@@ -65,6 +71,18 @@ describe("Asset Service", () => {
 
         it("detects an asset as unkonwn if it doesn't match well known file extensions", () => {
             const path = "C:\\dir1\\dir2\\asset1.docx";
+            const asset = AssetService.createAssetFromFilePath(path);
+            expect(asset.type).toEqual(AssetType.Unknown);
+        });
+
+        it("detects an asset in case asset name contains other file extension in the middle", () => {
+            const path = "C:\\dir1\\dir2\\asset1.docx.jpg";
+            const asset = AssetService.createAssetFromFilePath(path);
+            expect(asset.type).toEqual(AssetType.Image);
+        });
+
+        it("detects an asset in case asset name contains other file extension in the middle", () => {
+            const path = "C:\\dir1\\dir2\\asset1.jpg.docx";
             const asset = AssetService.createAssetFromFilePath(path);
             expect(asset.type).toEqual(AssetType.Unknown);
         });

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -33,9 +33,13 @@ export class AssetService {
         // fileNameParts[0] = "video"
         // fileNameParts[1] = "mp4"
         // fileNameParts[2] = "t=5"
-        const fileNameParts = pathParts[pathParts.length - 1].split(/[\.\?#]/);
-        fileName = fileName || `${fileNameParts[0]}.${fileNameParts[1]}`;
-        const assetFormat = fileNameParts.length >= 2 ? fileNameParts[1] : "";
+        fileName = pathParts[pathParts.length - 1];
+        const fileNameParts = fileName.split(/[\.\?#]/);
+        let assetFormat = fileNameParts[fileNameParts.length - 1];
+        if (fileNameParts.length >= 2 && this.getAssetType(fileNameParts[1]) === AssetType.Video) {
+            assetFormat = fileNameParts[1];
+        }
+
         const assetType = this.getAssetType(assetFormat);
 
         return {

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -33,7 +33,7 @@ export class AssetService {
         // fileNameParts[0] = "video"
         // fileNameParts[1] = "mp4"
         // fileNameParts[2] = "t=5"
-        fileName = pathParts[pathParts.length - 1];
+        fileName = fileName || pathParts[pathParts.length - 1];
         const fileNameParts = fileName.split(/[\.\?#]/);
         let assetFormat = fileNameParts[fileNameParts.length - 1];
         if (fileNameParts.length >= 2 && this.getAssetType(fileNameParts[1]) === AssetType.Video) {

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -34,11 +34,9 @@ export class AssetService {
         // fileNameParts[1] = "mp4"
         // fileNameParts[2] = "t=5"
         fileName = fileName || pathParts[pathParts.length - 1];
-        const fileNameParts = fileName.split(/[\.\?#]/);
-        let assetFormat = fileNameParts[fileNameParts.length - 1];
-        if (fileNameParts.length >= 2 && this.getAssetType(fileNameParts[1]) === AssetType.Video) {
-            assetFormat = fileNameParts[1];
-        }
+        const fileNameParts = fileName.split(".");
+        const extensionParts = fileNameParts[fileNameParts.length - 1].split(/[\?#]/);
+        const assetFormat = extensionParts[0];
 
         const assetType = this.getAssetType(assetFormat);
 


### PR DESCRIPTION
Resolve issue detecting asset type in case the file name contain more dot separator:

- ie file.jpg.tfrecord

