### PR TITLE
Refactor region tags to only be a string array

### DIFF
--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -156,7 +156,7 @@ export default class MockFactory {
         const mockRegion: IRegion = {
             id: id || "id",
             type: RegionType.Rectangle,
-            tags: [mockTag],
+            tags: [mockTag.name],
             points: [mockStartPoint, mockEndPoint],
             boundingBox: mockBoundingBox,
         };

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -242,7 +242,7 @@ export interface ISize {
 export interface IRegion {
     id: string;
     type: RegionType;
-    tags: ITag[];
+    tags: string[];
     points?: IPoint[];
     boundingBox?: IBoundingBox;
 }

--- a/src/providers/export/azureCustomVision.test.ts
+++ b/src/providers/export/azureCustomVision.test.ts
@@ -132,7 +132,7 @@ describe("Azure Custom Vision Export Provider", () => {
                         id: shortid.generate(),
                         type: RegionType.Rectangle,
                         tags: [
-                            testProject.tags[0],
+                            testProject.tags[0].name,
                         ],
                         boundingBox: {
                             left: 10,

--- a/src/providers/export/azureCustomVision.ts
+++ b/src/providers/export/azureCustomVision.ts
@@ -193,8 +193,8 @@ export class AzureCustomVisionProvider extends ExportProvider<IAzureCustomVision
         // Generate the regions for Azure Custom Vision
         assetMetadata.regions.forEach((region) => {
             if (region.boundingBox) {
-                region.tags.forEach((tag) => {
-                    const customVisionTag = tags[tag.name];
+                region.tags.forEach((tagName) => {
+                    const customVisionTag = tags[tagName];
                     if (customVisionTag) {
                         const boundingBox = this.getBoundingBoxValue(assetMetadata.asset.size, region.boundingBox);
                         const newRegion: IAzureCustomVisionRegion = {

--- a/src/providers/export/tensorFlowPascalVOC.test.ts
+++ b/src/providers/export/tensorFlowPascalVOC.test.ts
@@ -80,7 +80,7 @@ describe("TFPascalVOC Json Export Provider", () => {
                 const mockRegion: IRegion = {
                     id: "id",
                     type: RegionType.Rectangle,
-                    tags: [mockTag],
+                    tags: [mockTag.name],
                     points: [mockStartPoint, mockEndPoint],
                 };
 

--- a/src/providers/export/tensorFlowPascalVOC.ts
+++ b/src/providers/export/tensorFlowPascalVOC.ts
@@ -150,9 +150,9 @@ export class TFPascalVOCJsonExportProvider extends ExportProvider<ITFPascalVOCJs
                                                    region.type === RegionType.Square) &&
                                                    region.points.length === 2)
                                .forEach((region) => {
-                                    region.tags.forEach((tag) => {
+                                    region.tags.forEach((tagName) => {
                                         const objectInfo: IObjectInfo = {
-                                            name: tag.name,
+                                            name: tagName,
                                             xmin: region.points[0].x,
                                             ymin: region.points[0].y,
                                             xmax: region.points[1].x,
@@ -277,7 +277,7 @@ export class TFPascalVOCJsonExportProvider extends ExportProvider<ITFPascalVOCJs
                     asset.regions.forEach((region) => {
                         tags.forEach((tag) => {
                             const array = tagsDict.get(tag.name);
-                            if (region.tags.filter((regionTag) => regionTag.name === tag.name).length > 0) {
+                            if (region.tags.filter((tagName) => tagName === tag.name).length > 0) {
                                 array.push(`${asset.asset.name} 1`);
                             } else {
                                 array.push(`${asset.asset.name} -1`);

--- a/src/providers/export/tensorFlowRecords.test.ts
+++ b/src/providers/export/tensorFlowRecords.test.ts
@@ -74,7 +74,7 @@ describe("TFRecords Json Export Provider", () => {
                 const mockRegion: IRegion = {
                     id: "id",
                     type: RegionType.Rectangle,
-                    tags: [mockTag],
+                    tags: [mockTag.name],
                     points: [mockStartPoint, mockEndPoint],
                 };
 

--- a/src/providers/export/tensorFlowRecords.ts
+++ b/src/providers/export/tensorFlowRecords.ts
@@ -178,10 +178,11 @@ export class TFRecordsJsonExportProvider extends ExportProvider<ITFRecordsJsonEx
     private updateAssetTagArrays(element: IAssetMetadata, imageInfo: IImageInfo) {
         element.regions.filter((region) => region.boundingBox)
                                .forEach((region) => {
-                                    region.tags.forEach((tag) => {
-                                        const index = this.project.tags.map((pTag) => pTag.name).indexOf(tag.name);
+                                    region.tags.forEach((tagName) => {
+                                        const index = this.project.tags
+                                            .findIndex((projectTag) => projectTag.name === tagName);
 
-                                        imageInfo.text.push(tag.name);
+                                        imageInfo.text.push(tagName);
                                         imageInfo.label.push(index);
                                         imageInfo.xmin.push(region.boundingBox.left / imageInfo.width);
                                         imageInfo.ymin.push(region.boundingBox.top / imageInfo.height);

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -197,7 +197,7 @@ describe("Editor Canvas", () => {
         const newTag = MockFactory.createTestTag();
         canvas.onTagClicked(newTag);
         for (const region of wrapper.instance().state.selectedRegions) {
-            expect(region.tags.findIndex((tag) => tag === newTag)).toBeGreaterThanOrEqual(0);
+            expect(region.tags.findIndex((tag) => tag === newTag.name)).toBeGreaterThanOrEqual(0);
         }
     });
 });

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -271,8 +271,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
      * @param tag Tag to add or remove from region
      */
     private toggleTagOnRegion = (region: IRegion, tag: ITag) => {
-        CanvasHelpers.toggleTag(region.tags, tag);
-        this.editor.RM.updateTagsById(region.id, CanvasHelpers.getTagsDescriptor(region));
+        CanvasHelpers.toggleTag(region.tags, tag.name);
+        this.editor.RM.updateTagsById(region.id, CanvasHelpers.getTagsDescriptor(this.props.project.tags, region));
     }
 
     /**
@@ -293,7 +293,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             this.editor.RM.addRegion(
                 region.id,
                 this.editor.scaleRegionToFrameSize(loadedRegionData),
-                CanvasHelpers.getTagsDescriptor(region));
+                CanvasHelpers.getTagsDescriptor(this.props.project.tags, region));
         });
 
         // Set selected region to the last region

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -6,19 +6,19 @@ import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 
 describe("Canvas Helpers", () => {
     it("Adds a tag to list", () => {
-        const tags = MockFactory.createTestTags();
+        const tags = MockFactory.createTestTags().map((tag) => tag.name);
         const originalLength = tags.length;
         const newTag = MockFactory.createTestTag("New Tag");
         CanvasHelpers.toggleTag(
             tags,
-            newTag,
+            newTag.name,
         );
         expect(tags).toHaveLength(originalLength + 1);
-        expect(tags[tags.length - 1]).toEqual(newTag);
+        expect(tags[tags.length - 1]).toEqual(newTag.name);
     });
 
     it("Removes a tag from list", () => {
-        const tags = MockFactory.createTestTags();
+        const tags = MockFactory.createTestTags().map((tag) => tag.name);
         const originalLength = tags.length;
         const originalFirstTag = tags[0];
         CanvasHelpers.toggleTag(

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -3,6 +3,7 @@ import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
+import Guard from "../../../../common/guard";
 
 /**
  * Static functions to assist in operations within Canvas component
@@ -15,8 +16,8 @@ export default class CanvasHelpers {
      * @param tags Array of tags
      * @param tag Tag to toggle
      */
-    public static toggleTag(tags: ITag[], tag: ITag): void {
-        const tagIndex = tags.findIndex((existingTag) => existingTag.name === tag.name);
+    public static toggleTag(tags: string[], tag: string): void {
+        const tagIndex = tags.findIndex((existingTag) => existingTag === tag);
         if (tagIndex === -1) {
             // Tag isn't found within region tags, add it
             tags.push(tag);
@@ -44,8 +45,18 @@ export default class CanvasHelpers {
      * Create TagsDescriptor (CanvasTools) from IRegion
      * @param region IRegion from Canvas
      */
-    public static getTagsDescriptor(region: IRegion): TagsDescriptor {
-        return new TagsDescriptor(region.tags.map((tag) => new Tag(tag.name, tag.color)));
+    public static getTagsDescriptor(projectTags: ITag[], region: IRegion): TagsDescriptor {
+        Guard.null(projectTags);
+        Guard.null(region);
+
+        const tags = region.tags
+            .map((tagName) => {
+                const projectTag = projectTags.find((projectTag) => projectTag.name === tagName);
+                return projectTag ? new Tag(projectTag.name, projectTag.color) : null;
+            })
+            .filter((tag) => tag !== null);
+
+        return new TagsDescriptor(tags);
     }
 
     /**

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -60,12 +60,7 @@ function getMockAssetMetadata(testAssets, assetIndex = 0): IAssetMetadata {
         regions: [
             {
                 ...mockRegion,
-                tags: [
-                    {
-                        ...mockRegion.tags[0],
-                        color: expect.stringMatching(/^#[0-9a-f]{3,6}$/i),
-                    },
-                ],
+                tags: [mockRegion.tags[0]],
             },
         ],
     };
@@ -87,7 +82,7 @@ describe("Editor Page Component", () => {
         editorMock.prototype.addContentSource = jest.fn(() => Promise.resolve());
         editorMock.prototype.scaleRegionToSourceSize = jest.fn((regionData: any) => regionData);
         editorMock.prototype.RM = new RegionsManager(null, null);
-        editorMock.prototype.AS = {setSelectionMode: jest.fn()};
+        editorMock.prototype.AS = { setSelectionMode: jest.fn() };
     });
 
     beforeEach(() => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -81,7 +81,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         assets: [],
         childAssets: [],
         editorMode: EditorMode.Rectangle,
-        additionalSettings: {videoSettings: (this.props.project) ? this.props.project.videoSettings : null},
+        additionalSettings: { videoSettings: (this.props.project) ? this.props.project.videoSettings : null },
     };
 
     private loadingProjectAssets: boolean = false;
@@ -109,7 +109,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         if (!this.state.project && this.props.project) {
             this.setState({
                 project: this.props.project,
-                additionalSettings: {videoSettings: (this.props.project) ? this.props.project.videoSettings : null},
+                additionalSettings: { videoSettings: (this.props.project) ? this.props.project.videoSettings : null },
             });
         }
     }
@@ -187,17 +187,16 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             selectedRegions.map((region) => {
                 const selectedIndex = selectedAsset.regions.findIndex((r) => r.id === region.id);
                 const selectedRegion = selectedAsset.regions[selectedIndex];
-                const tagIndex = selectedRegion.tags.findIndex(
-                    (existingTag) => existingTag.name === tag.name);
+                const tagIndex = selectedRegion.tags.findIndex((existingTag) => existingTag === tag.name);
                 if (tagIndex === -1) {
-                    selectedRegion.tags.push(tag);
+                    selectedRegion.tags.push(tag.name);
                 } else {
                     selectedRegion.tags.splice(tagIndex, 1);
                 }
                 if (selectedRegion.tags.length) {
                     this.canvas.current.editor.RM.updateTagsById(selectedRegion.id,
-                        new TagsDescriptor(selectedRegion.tags.map((tempTag) => new Tag(tempTag.name,
-                            this.props.project.tags.find((t) => t.name === tempTag.name).color))));
+                        new TagsDescriptor(selectedRegion.tags.map((tempTag) => new Tag(tempTag,
+                            this.props.project.tags.find((t) => t.name === tempTag).color))));
                 } else {
                     this.canvas.current.editor.RM.updateTagsById(selectedRegion.id, null);
                 }

--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -262,14 +262,14 @@ describe("Asset Service", () => {
 
             expect(result.regions.length).toEqual(2);
             expect(result.regions[0].tags.length).toEqual(1);
-            expect(result.regions[0].tags[0].name).toEqual("a");
+            expect(result.regions[0].tags[0]).toEqual("a");
             expect(result.regions[0].points.length).toEqual(2);
             expect(result.regions[0].points[0].x).toEqual(0);
             expect(result.regions[0].points[0].y).toEqual(0);
             expect(result.regions[0].points[1].x).toEqual(300);
             expect(result.regions[0].points[1].y).toEqual(400);
             expect(result.regions[1].tags.length).toEqual(1);
-            expect(result.regions[1].tags[0].name).toEqual("b");
+            expect(result.regions[1].tags[0]).toEqual("b");
             expect(result.regions[1].points.length).toEqual(2);
             expect(Math.floor(result.regions[1].points[0].x)).toEqual(60);
             expect(Math.floor(result.regions[1].points[0].y)).toEqual(80);

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -2,8 +2,10 @@ import MD5 from "md5.js";
 import _ from "lodash";
 import * as shortid from "shortid";
 import Guard from "../common/guard";
-import { IAsset, AssetType, IProject, IAssetMetadata, AssetState,
-         IRegion, RegionType, ITFRecordMetadata } from "../models/applicationState";
+import {
+    IAsset, AssetType, IProject, IAssetMetadata, AssetState,
+    IRegion, RegionType, ITFRecordMetadata,
+} from "../models/applicationState";
 import { AssetProviderFactory, IAssetProvider } from "../providers/storage/assetProviderFactory";
 import { StorageProviderFactory, IStorageProvider } from "../providers/storage/storageProviderFactory";
 import { constants } from "../common/constants";
@@ -203,7 +205,7 @@ export class AssetService {
         // Add Regions from TFRecord in Regions
         for (let index = 0; index < objectArray.textArray.length; index++) {
             tagPos = tags.findIndex((tag) => tag === objectArray.textArray[index]);
-            if (tagPos < 0 ) {
+            if (tagPos < 0) {
                 tagPos = tags.length;
                 tags.push(objectArray.textArray[index]);
             }
@@ -211,10 +213,7 @@ export class AssetService {
             regions.push({
                 id: shortid.generate(),
                 type: RegionType.Rectangle,
-                tags: [{
-                    name: objectArray.textArray[index],
-                    color: TagColors[tagPos],
-                }],
+                tags: [objectArray.textArray[index]],
                 boundingBox: {
                     left: objectArray.xminArray[index] * objectArray.width,
                     top: objectArray.yminArray[index] * objectArray.height,
@@ -222,13 +221,13 @@ export class AssetService {
                     height: (objectArray.ymaxArray[index] - objectArray.yminArray[index]) * objectArray.height,
                 },
                 points: [{
-                            x: objectArray.xminArray[index] * objectArray.width,
-                            y: objectArray.yminArray[index] * objectArray.height,
-                        },
-                        {
-                             x: objectArray.xmaxArray[index] * objectArray.width,
-                             y: objectArray.ymaxArray[index] * objectArray.height,
-                        }],
+                    x: objectArray.xminArray[index] * objectArray.width,
+                    y: objectArray.yminArray[index] * objectArray.height,
+                },
+                {
+                    x: objectArray.xmaxArray[index] * objectArray.width,
+                    y: objectArray.ymaxArray[index] * objectArray.height,
+                }],
             });
         }
 
@@ -248,6 +247,6 @@ export class AssetService {
         const ymaxArray = reader.getArrayFeature(0, "image/object/bbox/ymax", FeatureType.Float) as number[];
         const textArray = reader.getArrayFeature(0, "image/object/class/text", FeatureType.String) as string[];
 
-        return {width, height, xminArray, yminArray, xmaxArray, ymaxArray, textArray};
+        return { width, height, xminArray, yminArray, xmaxArray, ymaxArray, textArray };
     }
 }

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -12,8 +12,6 @@ import { constants } from "../common/constants";
 import HtmlFileReader from "../common/htmlFileReader";
 import { TFRecordsReader } from "../providers/export/tensorFlowRecords/tensorFlowReader";
 import { FeatureType } from "../providers/export/tensorFlowRecords/tensorFlowBuilder";
-// tslint:disable-next-line:no-var-requires
-const TagColors = require("../react/components/common/tagsInput/tagColors.json");
 
 /**
  * @name - Asset Service
@@ -206,7 +204,6 @@ export class AssetService {
         for (let index = 0; index < objectArray.textArray.length; index++) {
             tagPos = tags.findIndex((tag) => tag === objectArray.textArray[index]);
             if (tagPos < 0) {
-                tagPos = tags.length;
                 tags.push(objectArray.textArray[index]);
             }
 


### PR DESCRIPTION
Updated `IRegion` `tags` to be an `string[]` vs`ITag[]`.

The list of project tags should be the source or truth for tags and all other areas should only reference tags by name.  This ensures that the tag colors always use those referenced directly by the project and not within an region stored data.