### PR TITLE
[AB#17027] add keyboard shortcut for navigating between video frames

### DIFF
--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -85,11 +85,13 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
                 <BigPlayButton position="center" />
                 <ControlBar autoHide={false}>
                     <CustomVideoPlayerButton order={1.1}
+                        accelerators={["ArrowLeft", "a", "A"]}
                         tooltip={strings.editorPage.videoPlayer.previousExpectedFrame.tooltip}
                         onClick={this.movePreviousExpectedFrame}>
                         <i className="fas fa-caret-left fa-lg" />
                     </CustomVideoPlayerButton>
                     <CustomVideoPlayerButton order={1.2}
+                        accelerators={["ArrowRight", "d", "D"]}
                         tooltip={strings.editorPage.videoPlayer.nextExpectedFrame.tooltip}
                         onClick={this.moveNextExpectedFrame}>
                         <i className="fas fa-caret-right fa-lg" />
@@ -99,13 +101,13 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
                     <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.25]} order={7.1} />
                     <VolumeMenuButton enabled order={7.2} />
                     <CustomVideoPlayerButton order={8.1}
-                        accelerators={["ArrowLeft"]}
+                        accelerators={["q", "Q"]}
                         tooltip={strings.editorPage.videoPlayer.previousTaggedFrame.tooltip}
                         onClick={this.movePreviousTaggedFrame}>
                         <i className="fas fa-step-backward"></i>
                     </CustomVideoPlayerButton>
                     <CustomVideoPlayerButton order={8.2}
-                        accelerators={["ArrowRight"]}
+                        accelerators={["e", "E"]}
                         tooltip={strings.editorPage.videoPlayer.nextTaggedFrame.tooltip}
                         onClick={this.moveNextTaggedFrame}>
                         <i className="fas fa-step-forward"></i>


### PR DESCRIPTION
1. q/e for navigating between tagged frames
1. a/d & left/right-arrow for navigating between non-tagged frames