### PR TITLE
fix: Navigating to homepage should't close any open project

### DIFF
--- a/src/react/components/common/filePicker/filePicker.tsx
+++ b/src/react/components/common/filePicker/filePicker.tsx
@@ -7,7 +7,7 @@ import HtmlFileReader from "../../../../common/htmlFileReader";
  * @member onChange - Function to call on change of file selection
  * @member onError - Function to call on file picking error
  */
-interface IFilePickerProps {
+export interface IFilePickerProps {
     onChange: (sender: SyntheticEvent, fileText: string | ArrayBuffer) => void;
     onError: (sender: SyntheticEvent, error: any) => void;
 }

--- a/src/react/components/pages/homepage/homePage.test.tsx
+++ b/src/react/components/pages/homepage/homePage.test.tsx
@@ -19,6 +19,7 @@ describe("Homepage Component", () => {
     let props: IHomepageProps = null;
     let wrapper: ReactWrapper = null;
     let deleteProjectSpy: jest.SpyInstance = null;
+    let closeProjectSpy: jest.SpyInstance = null;
     const recentProjects = MockFactory.createTestProjects(2);
 
     function createComponent(store, props: IHomepageProps): ReactWrapper {
@@ -39,12 +40,17 @@ describe("Homepage Component", () => {
         store = createStore(recentProjects);
         props = createProps();
         deleteProjectSpy = jest.spyOn(props.actions, "deleteProject");
+        closeProjectSpy = jest.spyOn(props.actions, "closeProject");
 
         wrapper = createComponent(store, props);
     });
 
     it("should render a New Project Link", () => {
         expect(wrapper.find(Link).props().to).toBe("/projects/create");
+    });
+
+    it("should not close projects when homepage loads", () => {
+        expect(closeProjectSpy).not.toBeCalled();
     });
 
     it("should call upload when 'Open Project' is clicked", () => {

--- a/src/react/components/pages/homepage/homePage.test.tsx
+++ b/src/react/components/pages/homepage/homePage.test.tsx
@@ -4,13 +4,16 @@ import { Provider } from "react-redux";
 import { BrowserRouter as Router, Link } from "react-router-dom";
 import { AnyAction, Store } from "redux";
 import MockFactory from "../../../../common/mockFactory";
-import { IApplicationState, IProject } from "../../../../models/applicationState";
+import { IApplicationState, IProject, AppError, ErrorCode } from "../../../../models/applicationState";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
 import createReduxStore from "../../../../redux/store/store";
 import ProjectService from "../../../../services/projectService";
 import CondensedList from "../../common/condensedList/condensedList";
-import FilePicker from "../../common/filePicker/filePicker";
+import FilePicker, { IFilePickerProps } from "../../common/filePicker/filePicker";
 import HomePage, { IHomepageProps } from "./homePage";
+
+jest.mock("../../common/cloudFilePicker/cloudFilePicker");
+import { CloudFilePicker, ICloudFilePickerProps } from "../../common/cloudFilePicker/cloudFilePicker";
 
 jest.mock("../../../../services/projectService");
 
@@ -59,6 +62,14 @@ describe("Homepage Component", () => {
         const spy = jest.spyOn(filePicker.instance() as FilePicker, "upload");
         fileUpload.simulate("click");
         expect(spy).toBeCalled();
+    });
+
+    it("should show an error if the uploaded file is invalid", () => {
+        const genericError = new Error("Error parsing project file JSON");
+        const expectedError = new AppError(ErrorCode.ProjectUploadError, "Error uploading project file");
+        const filePicker = wrapper.find(FilePicker) as ReactWrapper<IFilePickerProps>;
+
+        expect(() => filePicker.props().onError(null, genericError)).toThrowError(expectedError);
     });
 
     it("should render a file picker", () => {
@@ -116,6 +127,23 @@ describe("Homepage Component", () => {
         await MockFactory.flushUi();
 
         expect(uploadSpy).toBeCalled();
+        expect(openProjectSpy).toBeCalledWith(testProject);
+    });
+
+    it("opens the cloud picker when selecting the open cloud project button", () => {
+        const mockCloudFilePicker = CloudFilePicker as jest.Mocked<typeof CloudFilePicker>;
+
+        wrapper.find("a.cloud-open-project").first().simulate("click");
+        expect(mockCloudFilePicker.prototype.open).toBeCalled();
+    });
+
+    it("loads a cloud project after project file has been selected", () => {
+        const openProjectSpy = jest.spyOn(props.actions, "loadProject");
+        const testProject = MockFactory.createTestProject("TestProject");
+        const projectJson = JSON.stringify(testProject, null, 4);
+        const cloudFilePicker = wrapper.find(CloudFilePicker) as ReactWrapper<ICloudFilePickerProps>;
+        cloudFilePicker.props().onSubmit(projectJson);
+
         expect(openProjectSpy).toBeCalledWith(testProject);
     });
 

--- a/src/react/components/pages/homepage/homePage.tsx
+++ b/src/react/components/pages/homepage/homePage.tsx
@@ -71,7 +71,7 @@ export default class HomePage extends React.Component<IHomepageProps> {
                         </li>
                         <li>
                             {/*Open Cloud Project*/}
-                            <a href="#" onClick={this.handleOpenCloudProjectClick} className="p-5">
+                            <a href="#" onClick={this.handleOpenCloudProjectClick} className="p-5 cloud-open-project">
                                 <i className="fas fa-cloud fa-9x"></i>
                                 <h6>{strings.homePage.openCloudProject.title}</h6>
                             </a>

--- a/src/react/components/pages/homepage/homePage.tsx
+++ b/src/react/components/pages/homepage/homePage.tsx
@@ -22,6 +22,10 @@ export interface IHomepageProps extends RouteComponentProps, React.Props<HomePag
     actions: IProjectActions;
 }
 
+export interface IHomepageState {
+    cloudPickerOpen: boolean;
+}
+
 function mapStateToProps(state: IApplicationState) {
     return {
         recentProjects: state.recentProjects,
@@ -37,28 +41,13 @@ function mapDispatchToProps(dispatch) {
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class HomePage extends React.Component<IHomepageProps> {
-    private filePicker: React.RefObject<FilePicker>;
-    private deleteConfirm: React.RefObject<Confirm>;
-    private cloudFilePicker: React.RefObject<CloudFilePicker>;
+    public state: IHomepageState = {
+        cloudPickerOpen: false,
+    };
 
-    constructor(props: IHomepageProps, context) {
-        super(props, context);
-
-        this.state = {
-            cloudPickerOpen: false,
-        };
-
-        this.filePicker = React.createRef<FilePicker>();
-        this.deleteConfirm = React.createRef<Confirm>();
-        this.cloudFilePicker = React.createRef<CloudFilePicker>();
-
-        this.loadSelectedProject = this.loadSelectedProject.bind(this);
-        this.onProjectFileUpload = this.onProjectFileUpload.bind(this);
-        this.deleteProject = this.deleteProject.bind(this);
-        this.handleOpenCloudProjectClick = this.handleOpenCloudProjectClick.bind(this);
-
-        this.props.actions.closeProject();
-    }
+    private filePicker: React.RefObject<FilePicker> = React.createRef();
+    private deleteConfirm: React.RefObject<Confirm> = React.createRef();
+    private cloudFilePicker: React.RefObject<CloudFilePicker> = React.createRef();
 
     public render() {
         return (
@@ -114,7 +103,7 @@ export default class HomePage extends React.Component<IHomepageProps> {
         );
     }
 
-    private handleOpenCloudProjectClick() {
+    private handleOpenCloudProjectClick = () => {
         this.cloudFilePicker.current.open();
     }
 


### PR DESCRIPTION
The homepage was incorrectly closing any open project. This fix removes the explicit `closeProject` action and allows the user to navigate to the homepage and back to an open project if desired.

Resolves AB#17140