### PR TITLE
fix: Disables KeyboardManager when focused on input elements

### DIFF
--- a/src/react/components/common/keyboardManager/keyboardManager.test.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.test.tsx
@@ -7,6 +7,7 @@ jest.mock("./keyboardRegistrationManager");
 import { KeyboardRegistrationManager } from "./keyboardRegistrationManager";
 
 describe("Keyboard Manager Component", () => {
+    const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
     let wrapper: ReactWrapper<{}, IKeyboardContext> = null;
     let addEventListenerSpy: jest.SpyInstance = null;
     let removeEventListenerSpy: jest.SpyInstance = null;
@@ -20,6 +21,7 @@ describe("Keyboard Manager Component", () => {
     }
 
     beforeEach(() => {
+        (registrationManagerMock.prototype.invokeHandlers as any).mockClear();
         addEventListenerSpy = jest.spyOn(window, "addEventListener");
         removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
         wrapper = createComponent();
@@ -45,132 +47,179 @@ describe("Keyboard Manager Component", () => {
     it("listens for Ctrl+ keydown events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyDown, {
-            ctrlKey: true,
-            key: "1",
-        });
+                ctrlKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyDown, "Ctrl+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyDown, "Ctrl+1", keyboardEvent);
     });
 
     it("listens for Ctrl+ keyup events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyUp, {
-            ctrlKey: true,
-            key: "1",
-        });
+                ctrlKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyUp, "Ctrl+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyUp, "Ctrl+1", keyboardEvent);
     });
 
     it("listens for Ctrl+ keypress events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyPress, {
-            ctrlKey: true,
-            key: "1",
-        });
+                ctrlKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyPress, "Ctrl+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyPress, "Ctrl+1", keyboardEvent);
     });
 
     it("listens for Alt+ keydown events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyDown, {
-            ctrlKey: false,
-            altKey: true,
-            key: "1",
-        });
+                ctrlKey: false,
+                altKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyDown, "Alt+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyDown, "Alt+1", keyboardEvent);
     });
 
     it("listens for Alt+ keyup events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyUp, {
-            ctrlKey: false,
-            altKey: true,
-            key: "1",
-        });
+                ctrlKey: false,
+                altKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyUp, "Alt+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyUp, "Alt+1", keyboardEvent);
     });
 
     it("listens for Alt+ keypress events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyPress, {
-            ctrlKey: false,
-            altKey: true,
-            key: "1",
-        });
+                ctrlKey: false,
+                altKey: true,
+                key: "1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyPress, "Alt+1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyPress, "Alt+1", keyboardEvent);
     });
 
     it("listens for keydown events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyDown, {
-            ctrlKey: false,
-            altKey: false,
-            key: "F1",
-        });
+                ctrlKey: false,
+                altKey: false,
+                key: "F1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyDown, "F1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyDown, "F1", keyboardEvent);
     });
 
     it("listens for keyup events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyUp, {
-            ctrlKey: false,
-            altKey: false,
-            key: "F1",
-        });
+                ctrlKey: false,
+                altKey: false,
+                key: "F1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyUp, "F1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyUp, "F1", keyboardEvent);
     });
 
     it("listens for keypress events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyPress, {
-            ctrlKey: false,
-            altKey: false,
-            key: "F1",
-        });
+                ctrlKey: false,
+                altKey: false,
+                key: "F1",
+            });
 
         window.dispatchEvent(keyboardEvent);
 
-        const registrationManagerMock = KeyboardRegistrationManager as jest.Mocked<typeof KeyboardRegistrationManager>;
-        expect(registrationManagerMock.prototype.invokeHandlers).toBeCalledWith(
-            KeyEventType.KeyPress, "F1", keyboardEvent);
+        expect(registrationManagerMock.prototype.invokeHandlers)
+            .toBeCalledWith(KeyEventType.KeyPress, "F1", keyboardEvent);
+    });
+
+    describe("Disabling keyboard events for input form elements", () => {
+        it("ignores keypress events when UI is focused on an input element", () => {
+            const keyboardEvent = new KeyboardEvent(
+                KeyEventType.KeyPress, {
+                    ctrlKey: false,
+                    altKey: false,
+                    key: "a",
+                });
+
+            Object.defineProperty(document, "activeElement", {
+                get: jest.fn(() => document.createElement("input")),
+                configurable: true,
+            });
+
+            window.dispatchEvent(keyboardEvent);
+
+            expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
+        });
+
+        it("ignores keypress events when UI is focused on an textarea element", () => {
+            const keyboardEvent = new KeyboardEvent(
+                KeyEventType.KeyPress, {
+                    ctrlKey: false,
+                    altKey: false,
+                    key: "a",
+                });
+
+            Object.defineProperty(document, "activeElement", {
+                get: jest.fn(() => document.createElement("textarea")),
+                configurable: true,
+            });
+
+            window.dispatchEvent(keyboardEvent);
+
+            expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
+        });
+
+        it("does not ignore keypress events when UI is focused other elements", () => {
+            const keyboardEvent = new KeyboardEvent(
+                KeyEventType.KeyPress, {
+                    ctrlKey: false,
+                    altKey: false,
+                    key: "a",
+                });
+
+            Object.defineProperty(document, "activeElement", {
+                get: jest.fn(() => document.createElement("select")),
+                configurable: true,
+            });
+
+            window.dispatchEvent(keyboardEvent);
+
+            expect(registrationManagerMock.prototype.invokeHandlers).toBeCalled();
+        });
     });
 });

--- a/src/react/components/common/keyboardManager/keyboardManager.test.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.test.tsx
@@ -204,7 +204,7 @@ describe("Keyboard Manager Component", () => {
             expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
         });
 
-        it("does not ignore keyboard events when UI is focused on other elements", () => {
+        it("ignores keyboard events when UI is focused on select elements", () => {
             const keyboardEvent = new KeyboardEvent(
                 KeyEventType.KeyPress, {
                     ctrlKey: false,
@@ -214,6 +214,24 @@ describe("Keyboard Manager Component", () => {
 
             Object.defineProperty(document, "activeElement", {
                 get: jest.fn(() => document.createElement("select")),
+                configurable: true,
+            });
+
+            window.dispatchEvent(keyboardEvent);
+
+            expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
+        });
+
+        it("does not ignore keyboard events when UI is focused on other form elements", () => {
+            const keyboardEvent = new KeyboardEvent(
+                KeyEventType.KeyPress, {
+                    ctrlKey: false,
+                    altKey: false,
+                    key: "a",
+                });
+
+            Object.defineProperty(document, "activeElement", {
+                get: jest.fn(() => document.createElement("button")),
                 configurable: true,
             });
 

--- a/src/react/components/common/keyboardManager/keyboardManager.test.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.test.tsx
@@ -167,8 +167,8 @@ describe("Keyboard Manager Component", () => {
             .toBeCalledWith(KeyEventType.KeyPress, "F1", keyboardEvent);
     });
 
-    describe("Disabling keyboard events for input form elements", () => {
-        it("ignores keypress events when UI is focused on an input element", () => {
+    describe("Disabling keyboard manager", () => {
+        it("ignores keyboard events when UI is focused on an input element", () => {
             const keyboardEvent = new KeyboardEvent(
                 KeyEventType.KeyPress, {
                     ctrlKey: false,
@@ -186,7 +186,7 @@ describe("Keyboard Manager Component", () => {
             expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
         });
 
-        it("ignores keypress events when UI is focused on an textarea element", () => {
+        it("ignores keyboard events when UI is focused on an textarea element", () => {
             const keyboardEvent = new KeyboardEvent(
                 KeyEventType.KeyPress, {
                     ctrlKey: false,
@@ -204,7 +204,7 @@ describe("Keyboard Manager Component", () => {
             expect(registrationManagerMock.prototype.invokeHandlers).not.toBeCalled();
         });
 
-        it("does not ignore keypress events when UI is focused other elements", () => {
+        it("does not ignore keyboard events when UI is focused on other elements", () => {
             const keyboardEvent = new KeyboardEvent(
                 KeyEventType.KeyPress, {
                     ctrlKey: false,

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -24,7 +24,7 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
     };
 
     private nonSupportedKeys = new Set(["Ctrl", " Control", "Alt"]);
-    private inputElementTypes = new Set(["input", "textarea"]);
+    private inputElementTypes = new Set(["input", "select", "textarea"]);
 
     public componentDidMount() {
         window.addEventListener(KeyEventType.KeyDown, this.onKeyboardEvent);

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -63,24 +63,10 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
             return;
         }
 
-        const keyEventType = this.getKeyEventType(evt.type);
-        this.state.keyboard.invokeHandlers(keyEventType, this.getKeyParts(evt), evt);
+        this.state.keyboard.invokeHandlers(evt.type as KeyEventType, this.getKeyParts(evt), evt);
     }
 
     private isDisabled(): boolean {
         return document.activeElement && this.inputElementTypes.has(document.activeElement.tagName.toLowerCase());
-    }
-
-    private getKeyEventType(eventType: string): KeyEventType {
-        switch (eventType) {
-            case "keydown":
-                return KeyEventType.KeyDown;
-            case "keyup":
-                return KeyEventType.KeyUp;
-            case "keypress":
-                return KeyEventType.KeyPress;
-            default:
-                throw new Error("Unrecognized key event type");
-        }
     }
 }

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -24,17 +24,18 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
     };
 
     private nonSupportedKeys = new Set(["Ctrl", " Control", "Alt"]);
+    private inputElementTypes = new Set(["input", "textarea"]);
 
     public componentDidMount() {
-        window.addEventListener(KeyEventType.KeyDown, this.onKeyDown);
-        window.addEventListener(KeyEventType.KeyUp, this.onKeyUp);
-        window.addEventListener(KeyEventType.KeyPress, this.onKeyPress);
+        window.addEventListener(KeyEventType.KeyDown, this.onKeyboardEvent);
+        window.addEventListener(KeyEventType.KeyUp, this.onKeyboardEvent);
+        window.addEventListener(KeyEventType.KeyPress, this.onKeyboardEvent);
     }
 
     public componentWillUnmount() {
-        window.removeEventListener(KeyEventType.KeyDown, this.onKeyDown);
-        window.removeEventListener(KeyEventType.KeyUp, this.onKeyUp);
-        window.removeEventListener(KeyEventType.KeyPress, this.onKeyPress);
+        window.removeEventListener(KeyEventType.KeyDown, this.onKeyboardEvent);
+        window.removeEventListener(KeyEventType.KeyUp, this.onKeyboardEvent);
+        window.removeEventListener(KeyEventType.KeyPress, this.onKeyboardEvent);
     }
 
     public render() {
@@ -57,24 +58,29 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
         return keyParts.join("");
     }
 
-    private onKeyDown = (evt: KeyboardEvent) => {
-        if (this.nonSupportedKeys.has(evt.key)) {
+    private onKeyboardEvent = (evt: KeyboardEvent) => {
+        if (this.isDisabled() || this.nonSupportedKeys.has(evt.key)) {
             return;
         }
-        this.state.keyboard.invokeHandlers(KeyEventType.KeyDown, this.getKeyParts(evt), evt);
+
+        const keyEventType = this.getKeyEventType(evt.type);
+        this.state.keyboard.invokeHandlers(keyEventType, this.getKeyParts(evt), evt);
     }
 
-    private onKeyUp = (evt: KeyboardEvent) => {
-        if (this.nonSupportedKeys.has(evt.key)) {
-            return;
-        }
-        this.state.keyboard.invokeHandlers(KeyEventType.KeyUp, this.getKeyParts(evt), evt);
+    private isDisabled(): boolean {
+        return document.activeElement && this.inputElementTypes.has(document.activeElement.tagName.toLowerCase());
     }
 
-    private onKeyPress = (evt: KeyboardEvent) => {
-        if (this.nonSupportedKeys.has(evt.key)) {
-            return;
+    private getKeyEventType(eventType: string): KeyEventType {
+        switch (eventType) {
+            case "keydown":
+                return KeyEventType.KeyDown;
+            case "keyup":
+                return KeyEventType.KeyUp;
+            case "keypress":
+                return KeyEventType.KeyPress;
+            default:
+                throw new Error("Unrecognized key event type");
         }
-        this.state.keyboard.invokeHandlers(KeyEventType.KeyPress, this.getKeyParts(evt), evt);
     }
 }


### PR DESCRIPTION
Fixes an issue in the `KeyboardManager` component where a configured keyboard accelerator can override behavior when the user is entering data into a input/textarea element leading to a poor user experience.  Disables `KeyboardManager` events from firing when the app detects the user is focus in an input element.

Resolves AB#17120