### PR TITLE
fix: Correct bounding box values on region move

### DIFF
--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -27,6 +27,7 @@ import { AssetService } from "../services/assetService";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Selection/AreaSelector";
 import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 import { RegionDataType, RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
+import { randomIntInRange } from "./utils";
 
 export default class MockFactory {
 
@@ -563,12 +564,12 @@ export default class MockFactory {
      */
     public static createTestRegion(id = null): IRegion {
         const origin = {
-            x: MockFactory.randomNumber(0, 1024),
-            y: MockFactory.randomNumber(0, 768),
+            x: randomIntInRange(0, 1024),
+            y: randomIntInRange(0, 768),
         };
         const size = {
-            width: MockFactory.randomNumber(1, 100),
-            height: MockFactory.randomNumber(1, 100),
+            width: randomIntInRange(1, 100),
+            height: randomIntInRange(1, 100),
         };
 
         return {
@@ -595,12 +596,12 @@ export default class MockFactory {
      */
     public static createTestRegionData() {
         const origin = {
-            x: MockFactory.randomNumber(0, 1024),
-            y: MockFactory.randomNumber(0, 768),
+            x: randomIntInRange(0, 1024),
+            y: randomIntInRange(0, 768),
         };
         const size = {
-            width: MockFactory.randomNumber(1, 100),
-            height: MockFactory.randomNumber(1, 100),
+            width: randomIntInRange(1, 100),
+            height: randomIntInRange(1, 100),
         };
 
         return new RegionData(origin.x, origin.y, size.width, size.height,
@@ -909,9 +910,5 @@ export default class MockFactory {
             default:
                 return StorageType.Other;
         }
-    }
-
-    private static randomNumber(min: number, max: number) {
-        return Math.floor(Math.random() * max) + min;
     }
 }

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -3,7 +3,7 @@ import {
     AssetState, AssetType, IApplicationState, IAppSettings, IAsset, IAssetMetadata,
     IConnection, IExportFormat, IProject, ITag, StorageType, ISecurityToken,
     EditorMode, IAppError, IProjectVideoSettings, ErrorCode,
-    IPoint, IRegion, RegionType, IBoundingBox,
+    IRegion, RegionType,
 } from "../models/applicationState";
 import { ExportAssetState } from "../providers/export/exportProvider";
 import { IAssetProvider, IAssetProviderRegistrationOptions } from "../providers/storage/assetProviderFactory";
@@ -25,6 +25,8 @@ import { ILocalFileSystemProxyOptions } from "../providers/storage/localFileSyst
 import { generateKey } from "./crypto";
 import { AssetService } from "../services/assetService";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Selection/AreaSelector";
+import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
+import { RegionDataType, RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 
 export default class MockFactory {
 
@@ -128,40 +130,6 @@ export default class MockFactory {
         return [...Array(count).keys()].map((index) => {
             return this.createChildVideoAsset(rootAsset, index);
         });
-    }
-
-    /**
-     * Creates a mock region
-     */
-    public static createMockRegion(id?: string): IRegion {
-        const mockTag: ITag = MockFactory.createTestTag();
-
-        const mockStartPoint: IPoint = {
-            x: 1,
-            y: 2,
-        };
-
-        const mockEndPoint: IPoint = {
-            x: 3,
-            y: 4,
-        };
-
-        const mockBoundingBox: IBoundingBox = {
-            left: 0,
-            top: 0,
-            width: 256,
-            height: 256,
-        };
-
-        const mockRegion: IRegion = {
-            id: id || "id",
-            type: RegionType.Rectangle,
-            tags: [mockTag.name],
-            points: [mockStartPoint, mockEndPoint],
-            boundingBox: mockBoundingBox,
-        };
-
-        return mockRegion;
     }
 
     /**
@@ -577,7 +545,11 @@ export default class MockFactory {
         return new Canvas(canvasProps);
     }
 
-    public static createTestRegions(count= 5) {
+    /**
+     * Creates an array of test regions
+     * @param count The number of regions to create (deafult: 5)
+     */
+    public static createTestRegions(count: number = 5) {
         const regions: IRegion[] = [];
         for (let i = 1; i <= count; i++) {
             regions.push(MockFactory.createTestRegion(`test${i}`));
@@ -585,24 +557,61 @@ export default class MockFactory {
         return regions;
     }
 
-    public static createTestRegion(id = null) {
-        const testRegion: any = {
-            boundingBox: {
-                height: 100,
-                width: 100,
-                left: 0,
-                top: 0,
-            },
-            points: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }],
-            tags: [],
-            type: "RECTANGLE",
+    /**
+     * Creates a test region with the optional specified id
+     * @param id The id to assign to the region
+     */
+    public static createTestRegion(id = null): IRegion {
+        const origin = {
+            x: MockFactory.randomNumber(0, 1024),
+            y: MockFactory.randomNumber(0, 768),
         };
-        if (id) {
-            testRegion.id = id;
-        }
-        return testRegion;
+        const size = {
+            width: MockFactory.randomNumber(1, 100),
+            height: MockFactory.randomNumber(1, 100),
+        };
+
+        return {
+            id,
+            boundingBox: {
+                left: origin.x,
+                top: origin.y,
+                width: size.width,
+                height: size.height,
+            },
+            points: [
+                { x: origin.x, y: origin.y }, // Top left
+                { x: origin.x + size.width, y: origin.y }, // Top Right
+                { x: origin.x, y: origin.y + size.height }, // Bottom Left
+                { x: origin.x + size.width, y: origin.y + size.height }, // Bottom Right
+            ],
+            tags: [],
+            type: RegionType.Rectangle,
+        };
     }
 
+    /**
+     * Creates a random test canvas tool RegionData
+     */
+    public static createTestRegionData() {
+        const origin = {
+            x: MockFactory.randomNumber(0, 1024),
+            y: MockFactory.randomNumber(0, 768),
+        };
+        const size = {
+            width: MockFactory.randomNumber(1, 100),
+            height: MockFactory.randomNumber(1, 100),
+        };
+
+        return new RegionData(origin.x, origin.y, size.width, size.height,
+            [
+                new Point2D(origin.x, origin.y), // Top left
+                new Point2D(origin.x + size.width, origin.y), // Top Right
+                new Point2D(origin.x, origin.y + size.height), // Bottom Left
+                new Point2D(origin.x + size.width, origin.y + size.height), // Bottom Right
+            ],
+            RegionDataType.Rect);
+    }
     /**
      * Creates fake IAssetProviderRegistrationOptions
      * @param name Name of asset provider
@@ -900,5 +909,9 @@ export default class MockFactory {
             default:
                 return StorageType.Other;
         }
+    }
+
+    private static randomNumber(min: number, max: number) {
+        return Math.floor(Math.random() * max) + min;
     }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -7,15 +7,18 @@ import { encryptObject, decryptObject } from "./crypto";
  * @param min Lower bound of random number generation - INCLUSIVE
  * @param max Upper bound of random number generation - EXCLUSIVE
  */
-export function randomIntInRange(min, max) {
+export function randomIntInRange(min: number, max: number) {
     if (min > max) {
         throw new Error(`min (${min}) can't be bigger than max (${max})`);
     }
+
     if (min === max) {
         return min;
     }
+
     min = Math.ceil(min);
     max = Math.floor(max);
+
     return Math.floor(Math.random() * (max - min)) + min; // The maximum is exclusive and the minimum is inclusive
 }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -168,6 +168,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
         if (movedRegion) {
             movedRegion.points = scaledRegionData.points;
+            movedRegion.boundingBox = {
+                height: scaledRegionData.height,
+                width: scaledRegionData.width,
+                left: scaledRegionData.x,
+                top: scaledRegionData.y,
+            };
         }
 
         currentRegions[movedRegionIndex] = movedRegion;
@@ -205,7 +211,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         } else {
             selectedRegions = [region];
         }
-        this.setState({selectedRegions});
+        this.setState({ selectedRegions });
     }
 
     private renderChildren = () => {

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -1,4 +1,5 @@
-import { ITag, IRegion, RegionType } from "../../../../models/applicationState";
+import shortid from "shortid";
+import { ITag, IRegion, RegionType, EditorMode } from "../../../../models/applicationState";
 import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
@@ -39,6 +40,28 @@ export default class CanvasHelpers {
             region.points.map((point) =>
                 new Point2D(point.x, point.y)),
             this.regionTypeToType(region.type));
+    }
+
+    /**
+     * Converts a canvas tools RegionData to VoTT IRegion
+     * @param regionData The region data to convert
+     * @param regionType The region type
+     */
+    public static fromRegionData(regionData: RegionData, regionType: RegionType): IRegion {
+        Guard.null(regionData);
+
+        return {
+            id: shortid.generate(),
+            type: regionType,
+            boundingBox: {
+                left: regionData.x,
+                top: regionData.y,
+                width: regionData.width,
+                height: regionData.height,
+            },
+            points: regionData.points.map((point) => new Point2D(point.x, point.y)),
+            tags: [],
+        };
     }
 
     /**

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -49,25 +49,6 @@ function getState(wrapper): IEditorPageState {
     return wrapper.find(EditorPage).childAt(0).state() as IEditorPageState;
 }
 
-function getMockAssetMetadata(testAssets, assetIndex = 0): IAssetMetadata {
-    const mockRegion = MockFactory.createTestRegion();
-    const asset = testAssets[assetIndex];
-    const assetMetadata = {
-        asset: {
-            ...asset,
-            state: AssetState.Tagged,
-        },
-        regions: [
-            {
-                ...mockRegion,
-                tags: [mockRegion.tags[0]],
-            },
-        ],
-    };
-
-    return assetMetadata;
-}
-
 describe("Editor Page Component", () => {
     let assetServiceMock: jest.Mocked<typeof AssetService> = null;
     let projectServiceMock: jest.Mocked<typeof ProjectService> = null;
@@ -147,7 +128,7 @@ describe("Editor Page Component", () => {
         const props = MockFactory.editorPageProps(testProject.id);
 
         const wrapper = createComponent(store, props);
-        const editorPage = wrapper.find(EditorPage).childAt(0);
+        const editorPage = wrapper.find(EditorPage).childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
 
         const partialProject = {
             id: testProject.id,
@@ -156,11 +137,16 @@ describe("Editor Page Component", () => {
 
         await MockFactory.flushUi();
 
-        const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(projectAssets);
+        const expectedAsset = editorPage.state().assets[0];
 
         expect(editorPage.props().project).toEqual(expect.objectContaining(partialProject));
         expect(editorPage.state().assets.length).toEqual(projectAssets.length + testAssets.length);
-        expect(editorPage.state().selectedAsset).toMatchObject(expectedAssetMetadtata);
+        expect(editorPage.state().selectedAsset).toMatchObject({
+            asset: {
+                ...expectedAsset,
+                state: AssetState.Tagged,
+            },
+        });
     });
 
     it("Raises onAssetSelected handler when an asset is selected from the sidebar", async () => {
@@ -177,21 +163,26 @@ describe("Editor Page Component", () => {
         const saveProjectSpy = jest.spyOn(props.actions, "saveProject");
 
         // create mock editor page
-        createComponent(store, props);
+        const wrapper = createComponent(store, props);
+        const editorPage = wrapper.find(EditorPage).childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
 
+        await MockFactory.flushUi();
+
+        const expectedAsset = editorPage.state().assets[0];
         const partialProject = {
             id: testProject.id,
             name: testProject.name,
         };
 
-        const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets);
-
-        await MockFactory.flushUi();
-
         expect(loadAssetMetadataSpy).toBeCalledWith(expect.objectContaining(partialProject), defaultAsset);
         expect(saveAssetMetadataSpy).toBeCalledWith(
             expect.objectContaining(partialProject),
-            expectedAssetMetadtata,
+            expect.objectContaining({
+                asset: {
+                    ...expectedAsset,
+                    state: AssetState.Tagged,
+                },
+            }),
         );
         expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject));
     });
@@ -202,7 +193,7 @@ describe("Editor Page Component", () => {
             getAssetMetadataMock.mockImplementationOnce((asset) => {
                 const assetMetadata: IAssetMetadata = {
                     asset: { ...asset },
-                    regions: [{...MockFactory.createTestRegion(), tags: ["NEWTAG"]}],
+                    regions: [{ ...MockFactory.createTestRegion(), tags: ["NEWTAG"] }],
                 };
                 return Promise.resolve(assetMetadata);
             });
@@ -344,6 +335,7 @@ describe("Editor Page Component", () => {
     });
     describe("Basic toolbar test", () => {
         let wrapper: ReactWrapper = null;
+        let editorPage: ReactWrapper<IEditorPageProps, IEditorPageState> = null;
 
         beforeAll(() => {
             registerToolbar();
@@ -355,6 +347,7 @@ describe("Editor Page Component", () => {
             const props = MockFactory.editorPageProps(testProject.id);
 
             wrapper = createComponent(store, props);
+            editorPage = wrapper.find(EditorPage).childAt(0);
             await waitForSelectedAsset(wrapper);
         });
 
@@ -373,8 +366,8 @@ describe("Editor Page Component", () => {
             await MockFactory.flushUi(() => wrapper.find(NextAsset).simulate("click")); // Move to Asset 2
             wrapper.update();
 
-            const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets, 1);
-            expect(getState(wrapper).selectedAsset).toMatchObject(expectedAssetMetadtata);
+            const expectedAsset = editorPage.state().assets[1];
+            expect(getState(wrapper).selectedAsset).toMatchObject({ asset: expectedAsset });
         });
 
         it("selects the previous asset when clicking the 'Previous Asset' button in the toolbar", async () => {
@@ -384,8 +377,8 @@ describe("Editor Page Component", () => {
 
             wrapper.update();
 
-            const expectedAssetMetadtata: IAssetMetadata = getMockAssetMetadata(testAssets, 1);
-            expect(getState(wrapper).selectedAsset).toMatchObject(expectedAssetMetadtata);
+            const expectedAsset = editorPage.state().assets[1];
+            expect(getState(wrapper).selectedAsset).toMatchObject({ asset: expectedAsset });
         });
     });
 
@@ -456,9 +449,9 @@ describe("Editor Page Component", () => {
             wrapper.find(Canvas).find(AssetPreview).props().onLoaded(document.createElement("img"));
             await MockFactory.flushUi();
 
-            expect(editorPage.state().selectedAsset.regions[0].tags.length).toEqual(1);
+            expect(editorPage.state().selectedAsset.regions[0].tags.length).toEqual(0);
             wrapper.find(EditorFooter).props().onTagClicked(expectedTag);
-            expect(editorPage.state().selectedAsset.regions[0].tags.length).toEqual(2);
+            expect(editorPage.state().selectedAsset.regions[0].tags.length).toEqual(1);
         });
     });
 });

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -50,7 +50,7 @@ function getState(wrapper): IEditorPageState {
 }
 
 function getMockAssetMetadata(testAssets, assetIndex = 0): IAssetMetadata {
-    const mockRegion = MockFactory.createMockRegion();
+    const mockRegion = MockFactory.createTestRegion();
     const asset = testAssets[assetIndex];
     const assetMetadata = {
         asset: {
@@ -87,7 +87,7 @@ describe("Editor Page Component", () => {
         assetServiceMock.prototype.getAssetMetadata = jest.fn((asset) => {
             const assetMetadata: IAssetMetadata = {
                 asset: { ...asset },
-                regions: [MockFactory.createMockRegion()],
+                regions: [MockFactory.createTestRegion()],
             };
 
             return Promise.resolve(assetMetadata);
@@ -202,7 +202,7 @@ describe("Editor Page Component", () => {
             getAssetMetadataMock.mockImplementationOnce((asset) => {
                 const assetMetadata: IAssetMetadata = {
                     asset: { ...asset },
-                    regions: [{...MockFactory.createMockRegion(), tags: ["NEWTAG"]}],
+                    regions: [{...MockFactory.createTestRegion(), tags: ["NEWTAG"]}],
                 };
                 return Promise.resolve(assetMetadata);
             });
@@ -246,7 +246,7 @@ describe("Editor Page Component", () => {
 
         const editedImageAsset: IAssetMetadata = {
             asset: imageAsset,
-            regions: [MockFactory.createMockRegion()],
+            regions: [MockFactory.createTestRegion()],
         };
 
         const saveMock = assetServiceMock.prototype.save as jest.Mock;
@@ -310,7 +310,7 @@ describe("Editor Page Component", () => {
 
             const editedVideoFrame: IAssetMetadata = {
                 asset: videoFrames[0],
-                regions: [MockFactory.createMockRegion()],
+                regions: [MockFactory.createTestRegion()],
             };
 
             const saveMock = assetServiceMock.prototype.save as jest.Mock;


### PR DESCRIPTION
Corrects an issue where bounding box position was not being updated correctly when a region was moved within the canvas editor.  Also randomized region test data to ensure we are tests are more accurate