### PR TITLE
ci: add changelog script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# VoTT Changelog
+
+<!-- cl-start -->

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+# NOTE: To generate a changlelog, a git revision range is required. This can be commit SHAs,
+# but for all links in the template to work, tags are expected. The CWD should be set to the
+# root of the repository.
+echo "cwd=$(pwd)"
+
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -t|--to)
+      TO_COMMIT=$2
+      shift 2
+      ;;
+    -f|--from)
+      FROM_COMMIT=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+BASE_GITHUB_URL=https://github.com/Microsoft/VoTT
+RELEASE_DATE=$(date +"%m-%d-%Y")
+TEMPLATE="# [${TO_COMMIT}](${BASE_GITHUB_URL}/compare/${FROM_COMMIT}...${TO_COMMIT}) (${RELEASE_DATE})\n[GitHub Release](${BASE_GITHUB_URL}/releases/tag/${TO_COMMIT})\n\n"
+CL_START='<!-- cl-start -->'
+
+# Grab all non-merge commits (from PRs). Current PR policy is squash and merge,
+# using the fast-forward option, so merge commits *shouldn't* be present in the commit history.
+COMMITS=$(git log --pretty=%s --no-merges ${FROM_COMMIT}..${TO_COMMIT})
+
+echo "Generating changlog from ${FROM_COMMIT} to ${TO_COMMIT}..."
+while read -r line;
+do
+  echo "${line}"
+  TEMPLATE="${TEMPLATE}- ${line}\n"
+done <<< "${COMMITS}"
+
+# Attemped to use `sed` here, but between new lines and escape characters,
+# quickly became untenable. Python, perl and a couple other solutions come to mind,
+# but npm/JS are very xplat friendly and we're already using that tooling.
+# sed -i -e "s/${CL_START}/${CL_START}\n${TEMPLATE}/" CHANGELOG.md
+
+npm install replace-in-file --no-save
+./node_modules/.bin/replace-in-file "${CL_START}" "$(echo -e ${CL_START}\\n\\n${TEMPLATE})" CHANGELOG.md

--- a/scripts/release-pr.sh
+++ b/scripts/release-pr.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -p|--previous)
+      PREVIOUS_VERSION=$2
+      shift 2
+      ;;
+    -n|--new)
+      NEW_VERSION=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+BASEDIR=$(dirname "$0")
+PROMPT=$(echo -e "This will create changes to open a release PR for VoTT v${NEW_VERSION}?\nNOTE: a clean working git directory is required.\nDo you want to continue? [Y/n] ")
+RELEASE_BRANCH=release-${NEW_VERSION}
+
+read -p "${PROMPT}" -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "cwd=$(pwd)"
+    echo "basedir=${BASEDIR}"
+    echo "version=${NEW_VERSION}"
+
+    # get the latest from v2, create a release branch
+    git checkout v2
+    git pull
+    git checkout -b ${RELEASE_BRANCH}
+    echo "Creating local tag ${NEW_VERSION}"
+    git tag -a ${NEW_VERSION} -m "VoTT v${NEW_VERSION}"
+    # update package.json version and the changelog
+    npm install json --no-save
+    ./node_modules/.bin/json -I -f package.json -4 -e "this.version=\"${NEW_VERSION}\""
+    ${BASEDIR}/generate-changelog.sh --from ${PREVIOUS_VERSION} --to ${NEW_VERSION}
+    git commit -am "ci: update package version and changelog for ${NEW_VERSION} release"
+    git push -u origin ${RELEASE_BRANCH}
+    # remove the local tag, used for the changelog
+    echo "Deleting local tag ${NEW_VERSION}"
+    git tag -d ${NEW_VERSION}
+fi


### PR DESCRIPTION
This adds a new script for generating changelogs. Once integrated into CI, it will update `CHANGELOG.md` for new, tagged releases.

The changelog will look like this (generated fomr the current commit history): 

# [2.0.0-preview.2](https://github.com/Microsoft/VoTT/compare/2.0.0-cl.2...2.0.0-preview.2) (02-24-2019)
[GitHub Release](https://github.com/Microsoft/VoTT/releases/tag/2.0.0-preview.2)

- ci: add changelog script
- fix:Resolves issue where user is unable to create new project (#601)
- fix: Navigating to homepage should't close any open project (#596)
- feat: Add tag to project while importing TFRecords [AB#17001] (#586)
- fix: Disables KeyboardManager when focused on input elements (#595)
- fix: Corrects canvas sizing and region sizes (#592)

AB#17192