### PR TITLE
fix: Fixes issue where regions cannot be deleted

### DIFF
--- a/src/electron/providers/storage/localFileSystem.test.ts
+++ b/src/electron/providers/storage/localFileSystem.test.ts
@@ -84,4 +84,8 @@ describe("LocalFileSystem Storage Provider", () => {
 
         await expect(localFileSystem.selectContainer()).rejects.not.toBeNull();
     });
+
+    it("deleting file that doesn't exist resolves successfully", async () => {
+        await expect(localFileSystem.deleteFile("/path/to/fake/file.txt")).resolves.not.toBeNull();
+    });
 });

--- a/src/electron/providers/storage/localFileSystem.ts
+++ b/src/electron/providers/storage/localFileSystem.ts
@@ -78,15 +78,17 @@ export default class LocalFileSystem implements IStorageProvider {
     public deleteFile(filePath: string): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             const exists = fs.existsSync(path.normalize(filePath));
-            if (exists) {
-                fs.unlink(filePath, (err) => {
-                    if (err) {
-                        return reject(err);
-                    }
-
-                    resolve();
-                });
+            if (!exists) {
+                resolve();
             }
+
+            fs.unlink(filePath, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve();
+            });
         });
     }
 

--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -161,7 +161,7 @@ describe("Asset Service", () => {
             expect(result).toBe(assetMetadata);
         });
 
-        it("Does not save asset JSON to the storage provider if asset has not been tagged", async () => {
+        it("Deletes asset JSON from the storage provider if asset has not been tagged", async () => {
             const assetMetadata: IAssetMetadata = {
                 asset: {
                     ...testAssets[0],
@@ -173,6 +173,7 @@ describe("Asset Service", () => {
             const result = await assetService.save(assetMetadata);
 
             expect(storageProviderMock.writeText).not.toBeCalled();
+            expect(storageProviderMock.deleteFile).toBeCalled();
             expect(result).toBe(assetMetadata);
         });
 

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -166,6 +166,10 @@ export class AssetService {
         // Otherwise primary asset information is already persisted in the project file.
         if (metadata.asset.state === AssetState.Tagged) {
             await this.storageProvider.writeText(fileName, JSON.stringify(metadata, null, 4));
+        } else {
+            // If the asset is no longer tagged, then it doesn't contain any regions
+            // and the file is not required.
+            await this.storageProvider.deleteFile(fileName);
         }
 
         return metadata;


### PR DESCRIPTION
Fixes the issue where the last region in an asset is unable to be deleted.  When all the regions on an asset are deleted the asset transitions back into the "Visited" state.  Therefore, when the asset metadata is saved is is not persisted back to the file system since it is no longer in the "Tagged" state.  The fix is to instead of saving the asset metadata file it should be deleted from the storage provider since the asset metadata file doesn't not provide any additional metadata outside of region data.

Resolves AB#17174