### PR TITLE
(TEST)feat: Ability to retain the state of the last viewed asset on project open [#AB17139]

### DIFF
--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -108,6 +108,7 @@ export interface IProject {
     videoSettings: IProjectVideoSettings;
     autoSave: boolean;
     assets?: { [index: string]: IAsset };
+    lastVisitedAssetId?: string;
 }
 
 /**

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -189,6 +189,46 @@ describe("Editor Page Component", () => {
         expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject));
     });
 
+    it("Check correct saving and loading of last visited asset", async () => {
+        // create test project and asset
+        const testProject = MockFactory.createTestProject("TestProject");
+        testProject.lastVisitedAssetId = testAssets[1].id;
+        const defaultAsset = testAssets[1];
+
+        // mock store and props
+        const store = createStore(testProject, true);
+        const props = MockFactory.editorPageProps(testProject.id);
+
+        const loadAssetMetadataSpy = jest.spyOn(props.actions, "loadAssetMetadata");
+        const saveAssetMetadataSpy = jest.spyOn(props.actions, "saveAssetMetadata");
+        const saveProjectSpy = jest.spyOn(props.actions, "saveProject");
+
+        // create mock editor page
+        const wrapper = createComponent(store, props);
+        const editorPage = wrapper.find(EditorPage).childAt(0) as ReactWrapper<IEditorPageProps, IEditorPageState>;
+
+        await MockFactory.flushUi();
+
+        const expectedAsset = editorPage.state().assets[1];
+        const partialProject = {
+            id: testProject.id,
+            name: testProject.name,
+            lastVisitedAssetId: testAssets[1].id,
+        };
+
+        expect(loadAssetMetadataSpy).toBeCalledWith(expect.objectContaining(partialProject), defaultAsset);
+        expect(saveAssetMetadataSpy).toBeCalledWith(
+            expect.objectContaining(partialProject),
+            expect.objectContaining({
+                asset: {
+                    ...expectedAsset,
+                    state: AssetState.Tagged,
+                },
+            }),
+        );
+        expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject));
+    });
+
     describe("Editor Page Component Forcing Tag Scenario", () => {
         it("Detect new Tag from asset metadata when selecting the Asset", async () => {
             const getAssetMetadataMock = assetServiceMock.prototype.getAssetMetadata as jest.Mock;

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -409,11 +409,13 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             .uniqBy((asset) => asset.id)
             .value();
 
+        const lastVisited = rootAssets.find((asset) => asset.id === this.props.project.lastVisitedAssetId);
+
         this.setState({
             assets: rootAssets,
         }, async () => {
             if (rootAssets.length > 0) {
-                await this.selectAsset(rootAssets[0]);
+                await this.selectAsset(lastVisited ? lastVisited : rootAssets[0]);
             }
             this.loadingProjectAssets = false;
         });

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -258,10 +258,12 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             rootAsset.state = rootAssetMetadata.asset.state;
         }
 
-        await this.props.actions.saveAssetMetadata(this.props.project, assetMetadata);
-        await this.props.actions.saveProject(this.props.project);
+        const newProject = {...this.props.project, lastVisitedAssetId: assetMetadata.asset.id};
 
-        const assetService = new AssetService(this.props.project);
+        await this.props.actions.saveAssetMetadata(newProject, assetMetadata);
+        await this.props.actions.saveProject(newProject);
+
+        const assetService = new AssetService(newProject);
         const childAssets = assetService.getChildAssets(rootAsset);
 
         // Find and update the root asset in the internal state


### PR DESCRIPTION
* Save last visited asset id on project save
* Scroll to last visited asset on opening project
* Added unit test to check save and load of last visited asset info

Implement [#AB17139]