### PR TITLE
feat: add hotkeys for all editor toolbar items and simplify tag input hotkeys (remove ctrl+)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,7 +2924,7 @@
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-            "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "requires": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -4006,7 +4006,7 @@
         "create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-            "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "requires": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -4018,7 +4018,7 @@
         "create-hmac": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-            "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "requires": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -4685,7 +4685,7 @@
         "diffie-hellman": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-            "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "requires": {
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
@@ -7900,7 +7900,7 @@
         "hash.js": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-            "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
@@ -15933,7 +15933,7 @@
         "sha.js": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -17625,7 +17625,7 @@
                 "cacache": {
                     "version": "10.0.4",
                     "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-                    "integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
+                    "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
                     "requires": {
                         "bluebird": "^3.5.1",
                         "chownr": "^1.0.1",

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -1,5 +1,14 @@
 import React from "react";
-import { KeyboardRegistrationManager, KeyEventType } from "./keyboardRegistrationManager";
+import { KeyboardRegistrationManager } from "./keyboardRegistrationManager";
+
+/**
+ * Types of Key events supported by registration manager
+ */
+export enum KeyEventType {
+    KeyDown = "keydown",
+    KeyUp = "keyup",
+    KeyPress = "keypress",
+}
 
 export const KeyboardContext = React.createContext<IKeyboardContext>(null);
 

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -1,16 +1,7 @@
 import React from "react";
-import { KeyboardRegistrationManager } from "./keyboardRegistrationManager";
+import { KeyboardRegistrationManager, KeyEventType } from "./keyboardRegistrationManager";
 
 export const KeyboardContext = React.createContext<IKeyboardContext>(null);
-
-/**
- * Types of Key events supported by registration manager
- */
-export enum KeyEventType {
-    KeyDown = "keydown",
-    KeyUp = "keyup",
-    KeyPress = "keypress",
-}
 
 export interface IKeyboardContext {
     keyboard: KeyboardRegistrationManager;

--- a/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
+++ b/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
@@ -1,6 +1,6 @@
 import Guard from "../../../../common/guard";
 import { KeyEventType } from "./keyboardManager";
-
+// FIXME: should KeyEventType enum in keyboardManager be moved here to avoid circular dependency?
 /**
  * A map of keyboard event registrations
  */

--- a/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
+++ b/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
@@ -1,13 +1,5 @@
 import Guard from "../../../../common/guard";
-
-/**
- * Types of Key events supported by registration manager
- */
-export enum KeyEventType {
-    KeyDown = "keydown",
-    KeyUp = "keyup",
-    KeyPress = "keypress",
-}
+import { KeyboardManager, KeyEventType } from "./keyboardManager";
 
 /**
  * A map of keyboard event registrations

--- a/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
+++ b/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
@@ -1,6 +1,14 @@
 import Guard from "../../../../common/guard";
-import { KeyEventType } from "./keyboardManager";
-// FIXME: should KeyEventType enum in keyboardManager be moved here to avoid circular dependency?
+
+/**
+ * Types of Key events supported by registration manager
+ */
+export enum KeyEventType {
+    KeyDown = "keydown",
+    KeyUp = "keyup",
+    KeyPress = "keypress",
+}
+
 /**
  * A map of keyboard event registrations
  */

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -136,7 +136,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     return (<KeyboardBinding
                         key={index}
                         keyEventType={KeyEventType.KeyDown}
-                        accelerators={[`Ctrl+${index}`]}
+                        accelerators={[`${index}`]}
                         onKeyEvent={this.handleTagHotKey} />);
                 })}
                 <div className="editor-page-sidebar bg-lighter-1">

--- a/src/react/components/pages/editorPage/editorToolbar.test.tsx
+++ b/src/react/components/pages/editorPage/editorToolbar.test.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import _ from "lodash";
 import { EditorToolbar, IEditorToolbarProps, IEditorToolbarState } from "./editorToolbar";
 import MockFactory from "../../../../common/mockFactory";
-import { ToolbarItemFactory } from "../../../../providers/toolbar/toolbarItemFactory";
 import registerToolbar, { ToolbarItemName } from "../../../../registerToolbar";
+import { ToolbarItemFactory } from "../../../../providers/toolbar/toolbarItemFactory";
 import { ReactWrapper, mount } from "enzyme";
 import { ExportProject } from "../../toolbar/exportProject";
 import { ToolbarItem } from "../../toolbar/toolbarItem";
@@ -64,5 +64,11 @@ describe("Editor Toolbar", () => {
 
         const toolbar = wrapper.find(EditorToolbar) as ReactWrapper<IEditorToolbarProps, IEditorToolbarState>;
         expect(toolbar.state().selectedItem).toEqual(ToolbarItemName.ExportProject);
+    });
+
+    it("Sets correct keyboard binding when accelerator is defined", () => {
+        const drawRectangle = wrapper.find(ToolbarItemName.DrawRectangle).first();
+        expect(drawRectangle.exists()).toBe(true);
+        expect(drawRectangle).toContain("r");
     });
 });

--- a/src/react/components/pages/editorPage/editorToolbar.test.tsx
+++ b/src/react/components/pages/editorPage/editorToolbar.test.tsx
@@ -58,8 +58,7 @@ describe("Editor Toolbar", () => {
     });
 
     it("Sets the selected toolbar item", async () => {
-        const exportProject = wrapper.find(ExportProject).first();
-        expect(exportProject.exists()).toBe(true);
+        const exportProject = wrapper.find(".exportProject");
         exportProject.find("button").simulate("click");
 
         const toolbar = wrapper.find(EditorToolbar) as ReactWrapper<IEditorToolbarProps, IEditorToolbarState>;
@@ -67,8 +66,10 @@ describe("Editor Toolbar", () => {
     });
 
     it("Sets correct keyboard binding when accelerator is defined", () => {
-        const drawRectangle = wrapper.find(ToolbarItemName.DrawRectangle).first();
-        expect(drawRectangle.exists()).toBe(true);
-        expect(drawRectangle).toContain("r");
+        const toolbar = wrapper.find(EditorToolbar) as ReactWrapper<IEditorToolbarProps, IEditorToolbarState>;
+        const select = toolbar.props().items[0];
+        const toolbarRegistry = ToolbarItemFactory.getToolbarItems();
+        expect(select.config).toHaveProperty("accelerators", ["v", "V" ]);
+        expect(select.config).toEqual(toolbarRegistry[0].config);
     });
 });

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -31,26 +31,29 @@ export enum ToolbarItemGroup {
 export default function registerToolbar() {
     ToolbarItemFactory.register({
         name: ToolbarItemName.SelectCanvas,
-        tooltip: "Select",
+        tooltip: "Select (V)",
         icon: "fa-mouse-pointer",
         group: ToolbarItemGroup.Canvas,
         type: ToolbarItemType.State,
+        accelerators: ["v", "V"],
     });
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.DrawRectangle,
-        tooltip: "Draw Rectangle",
+        tooltip: "Draw Rectangle (R)",
         icon: "fa-vector-square",
         group: ToolbarItemGroup.Canvas,
         type: ToolbarItemType.State,
+        accelerators: ["r", "R"],
     });
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.DrawPolygon,
-        tooltip: "Draw Polygon",
+        tooltip: "Draw Polygon (P)",
         icon: "fa-draw-polygon",
         group: ToolbarItemGroup.Canvas,
         type: ToolbarItemType.State,
+        accelerators: ["p", "P"],
     });
 
     ToolbarItemFactory.register({
@@ -86,12 +89,11 @@ export default function registerToolbar() {
         icon: "fa-trash-alt",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+e"],
     });
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.PreviousAsset,
-        tooltip: "Previous Asset",
+        tooltip: "Previous Asset (W)",
         icon: "fas fa-arrow-circle-up",
         group: ToolbarItemGroup.Navigation,
         type: ToolbarItemType.Action,
@@ -100,7 +102,7 @@ export default function registerToolbar() {
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.NextAsset,
-        tooltip: "Next Asset",
+        tooltip: "Next Asset (S)",
         icon: "fas fa-arrow-circle-down",
         group: ToolbarItemGroup.Navigation,
         type: ToolbarItemType.Action,
@@ -109,7 +111,7 @@ export default function registerToolbar() {
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.SaveProject,
-        tooltip: "Save Project",
+        tooltip: "Save Project (Ctrl+S)",
         icon: "fa-save",
         group: ToolbarItemGroup.Project,
         type: ToolbarItemType.Action,
@@ -117,10 +119,10 @@ export default function registerToolbar() {
 
     ToolbarItemFactory.register({
         name: ToolbarItemName.ExportProject,
-        tooltip: "Export Project",
+        tooltip: "Export Project (Ctrl+E)",
         icon: "fa-external-link-square-alt",
         group: ToolbarItemGroup.Project,
         type: ToolbarItemType.Action,
-    }, ExportProject);
-
+        accelerators: ["Ctrl+e", "Ctrl+E"],
+    });
 }


### PR DESCRIPTION
This feature aims to make it easier for a user to keep one hand on the keyboard and one on the mouse for more efficient tagging of large quantities of images. Previous Asset (W) and Next Asset (S) already exists. This feature adds hotkeys to the editor toolbar as follows:
- Select (V) (following common hotkey convention)
- Draw Rectangle (R)
- Draw Polygon (P)
- Save Project (Ctrl + S)
- Export Project (Ctrl + E)
In addition, tag hotkeys have been simplified to numbers 1 through 0, instead of Ctrl + 1, etc.

AB#17096