### PR TITLE
ci: make sure build fail if codecov token is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # VoTT (Visual Object Tagging Tool)
 
-[![Build Status](https://dev.azure.com/msft-vott/VoTT/_apis/build/status/VoTT/VoTT-CI?branchName=v2)](https://dev.azure.com/msft-vott/VoTT/_build/latest?definitionId=6&branchName=v2)
-[![Code Coverage](https://codecov.io/gh/Microsoft/VoTT/branch/v2/graph/badge.svg)](https://codecov.io/gh/Microsoft/VoTT)[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Microsoft_VoTT&metric=alert_status)](https://sonarcloud.io/dashboard?id=Microsoft_VoTT)
+[![Build Status](https://dev.azure.com/msft-vott/VoTT/_apis/build/status/Microsoft.VoTT?branchName=v2)](https://dev.azure.com/msft-vott/VoTT/_build/latest?definitionId=25&branchName=v2)
+[![Code Coverage](https://codecov.io/gh/Microsoft/VoTT/branch/v2/graph/badge.svg)](https://codecov.io/gh/Microsoft/VoTT)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Microsoft_VoTT&metric=alert_status)](https://sonarcloud.io/dashboard?id=Microsoft_VoTT)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=Microsoft_VoTT&metric=ncloc)](https://sonarcloud.io/dashboard?id=Microsoft_VoTT)
 
 [Current Complexity Analysis Report](https://vottv2.z5.web.core.windows.net/)

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -30,7 +30,8 @@ steps:
   displayName: 'Run tests and coverage'
 
 - bash: |
-    set -e
+    # u flag will exit if there's any unbound variable
+    set -eu
 
     # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -32,11 +32,12 @@ steps:
 - bash: |
     set -e
 
-    if [[ -z "${CODECOV_TOKEN}" ]]; then
+    token=$(CODECOV_TOKEN)
+    if [[ -z "${token}" ]]; then
       echo "Need to set CODECOV_TOKEN"
       exit 1
     fi
 
-      # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
-    bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
+    # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
+    bash <(curl -s https://codecov.io/bash) -t ${token}
   displayName: 'Upload coverage report'

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -5,7 +5,7 @@
 steps:
 - bash: |
     set -e
-    
+
     sudo apt-get update
     sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 libgconf-2-4 dbus xvfb libgtk-3-0
     sudo cp azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
@@ -30,6 +30,8 @@ steps:
   displayName: 'Run tests and coverage'
 
 - bash: |
+    set -e
+
     # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
   displayName: 'Upload coverage report'

--- a/azure-pipelines/linux/continuous-build-linux.yml
+++ b/azure-pipelines/linux/continuous-build-linux.yml
@@ -30,9 +30,13 @@ steps:
   displayName: 'Run tests and coverage'
 
 - bash: |
-    # u flag will exit if there's any unbound variable
-    set -eu
+    set -e
 
-    # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
-    bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
+    if [[ -z "${CODECOV_TOKEN}" ]]; then
+      echo "Need to set CODECOV_TOKEN"
+      exit 1
+    fi
+
+      # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
+    bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
   displayName: 'Upload coverage report'


### PR DESCRIPTION
also update README to point ADO badge to new CI pipeline

have to create a new pipeline using the new YAML wizard
so that GitHub Pipelines App is used instead of webhook.

This fix the issue where re-running the ADO build from the
`Check` tab in GitHub doesn't kick off actual build in ADO.