### PR TITLE
fix: Move last visited tag settings to reducer to fix delete file assets bug [#AB17101]

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -275,12 +275,10 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             rootAsset.state = rootAssetMetadata.asset.state;
         }
 
-        const newProject = {...this.props.project, lastVisitedAssetId: assetMetadata.asset.id};
+        await this.props.actions.saveAssetMetadata(this.props.project, assetMetadata);
+        await this.props.actions.saveProject(this.props.project);
 
-        await this.props.actions.saveAssetMetadata(newProject, assetMetadata);
-        await this.props.actions.saveProject(newProject);
-
-        const assetService = new AssetService(newProject);
+        const assetService = new AssetService(this.props.project);
         const childAssets = assetService.getChildAssets(rootAsset);
 
         // Find and update the root asset in the internal state

--- a/src/redux/reducers/currentProjectReducer.test.ts
+++ b/src/redux/reducers/currentProjectReducer.test.ts
@@ -97,6 +97,7 @@ describe("Current Project Reducer", () => {
         const result = reducer(state, action);
         expect(result).not.toBe(state);
         expect(result.assets[testAssets[0].id]).toEqual(assetMetadata.asset);
+        expect(result.lastVisitedAssetId).toEqual(assetMetadata.asset.id);
     });
 
     it("Unknown action performs a noop", () => {

--- a/src/redux/reducers/currentProjectReducer.ts
+++ b/src/redux/reducers/currentProjectReducer.ts
@@ -32,6 +32,7 @@ export const reducer = (state: IProject = null, action: AnyAction): IProject => 
             return {
                 ...state,
                 assets: updatedAssets,
+                lastVisitedAssetId: action.payload.asset.id,
             };
         case ActionTypes.SAVE_CONNECTION_SUCCESS:
             if (!state) {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -75,7 +75,6 @@ export default class ProjectService implements IProjectService {
 
         // Delete all asset metadata files created for project
         const deleteFiles = _.values(project.assets)
-            .filter((asset) => asset.state === AssetState.Tagged)
             .map((asset) => storageProvider.deleteFile(`${asset.id}${constants.assetMetadataFileExtension}`));
 
         await Promise.all(deleteFiles);


### PR DESCRIPTION
- Move last visited tag settings from editor Page to project Redux action
- Removed non necessary filter on selecting asset files to delete

Fix bug [#AB17101]