### PR TITLE
fix: Fixes issue where calls to deleted non existent blobs causes editor issues

### DIFF
--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -170,7 +170,11 @@ export class AssetService {
         } else {
             // If the asset is no longer tagged, then it doesn't contain any regions
             // and the file is not required.
-            await this.storageProvider.deleteFile(fileName);
+            try {
+                await this.storageProvider.deleteFile(fileName);
+            } catch (err) {
+                // The file may not exist - that's OK
+            }
         }
 
         return metadata;


### PR DESCRIPTION
When a asset is in the visited state, the app attempts to delete the asset metadata file to prevent an explosion of files in the event an asset transitions from tagged back to visited.  This adds protections around the call to the storage provider to catch any unhandled delete failures.