### PR TITLE
(WIP)fix: Export ALL assets VS Visited/Tagged [#AB17365]

### DIFF
--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -110,7 +110,7 @@ export interface IProject {
     videoSettings: IProjectVideoSettings;
     autoSave: boolean;
     assets?: { [index: string]: IAsset };
-    allAssetsIds?: string[];
+    allAssets?: IAsset[];
     lastVisitedAssetId?: string;
 }
 

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -110,6 +110,7 @@ export interface IProject {
     videoSettings: IProjectVideoSettings;
     autoSave: boolean;
     assets?: { [index: string]: IAsset };
+    allAssetsIds?: string[];
     lastVisitedAssetId?: string;
 }
 

--- a/src/providers/export/azureCustomVision.test.ts
+++ b/src/providers/export/azureCustomVision.test.ts
@@ -60,6 +60,8 @@ describe("Azure Custom Vision Export Provider", () => {
                 },
             },
         };
+
+        testProject.allAssets = _.values(testProject.assets);
     });
 
     it("Is Defined", () => {

--- a/src/providers/export/exportProvider.test.ts
+++ b/src/providers/export/exportProvider.test.ts
@@ -22,6 +22,7 @@ describe("Export Provider Base", () => {
                 "asset-5": MockFactory.createTestAsset("5", AssetState.Tagged, null, AssetType.VideoFrame),
             },
         };
+        testProject.allAssets = _.values(testProject.assets);
     });
 
     it("initializes the asset and storage providers", () => {

--- a/src/providers/export/exportProvider.ts
+++ b/src/providers/export/exportProvider.ts
@@ -77,11 +77,11 @@ export abstract class ExportProvider<TOptions> implements IExportProvider {
         switch (this.options.assetState) {
             case ExportAssetState.Visited:
                 predicate = (asset) => asset.state === AssetState.Visited || asset.state === AssetState.Tagged;
-                source = await _.values(this.project.assets);
+                source = _.values(this.project.assets);
                 break;
             case ExportAssetState.Tagged:
                 predicate = (asset) => asset.state === AssetState.Tagged;
-                source = await _.values(this.project.assets);
+                source = _.values(this.project.assets);
                 break;
             case ExportAssetState.All:
             default:

--- a/src/providers/export/exportProvider.ts
+++ b/src/providers/export/exportProvider.ts
@@ -71,23 +71,26 @@ export abstract class ExportProvider<TOptions> implements IExportProvider {
      */
     public async getAssetsForExport(): Promise<IAssetMetadata[]> {
         let predicate: (asset: IAsset) => boolean = null;
+        let source: IAsset[] = null;
 
         // @ts-ignore
         switch (this.options.assetState) {
             case ExportAssetState.Visited:
                 predicate = (asset) => asset.state === AssetState.Visited || asset.state === AssetState.Tagged;
+                source = await _.values(this.project.assets);
                 break;
             case ExportAssetState.Tagged:
                 predicate = (asset) => asset.state === AssetState.Tagged;
+                source = await _.values(this.project.assets);
                 break;
             case ExportAssetState.All:
             default:
                 predicate = () => true;
+                source = this.project.allAssets;
                 break;
         }
 
-        return await _.values(this.project.assets)
-            .filter((asset) => asset.type !== AssetType.Video)
+        return await source.filter((asset) => asset.type !== AssetType.Video)
             .filter(predicate)
             .mapAsync(async (asset) => await this.assetService.getAssetMetadata(asset));
     }

--- a/src/providers/export/tensorFlowPascalVOC.test.ts
+++ b/src/providers/export/tensorFlowPascalVOC.test.ts
@@ -35,6 +35,7 @@ describe("TFPascalVOC Json Export Provider", () => {
         "asset-3": MockFactory.createTestAsset("3", AssetState.Visited),
         "asset-4": MockFactory.createTestAsset("4", AssetState.NotVisited),
     };
+    baseTestProject.allAssets = _.values(baseTestProject.assets);
     baseTestProject.sourceConnection = MockFactory.createTestConnection("test", "localFileSystemProxy");
     baseTestProject.targetConnection = MockFactory.createTestConnection("test", "localFileSystemProxy");
 

--- a/src/providers/export/tensorFlowRecords.test.ts
+++ b/src/providers/export/tensorFlowRecords.test.ts
@@ -14,6 +14,7 @@ jest.mock("../storage/localFileSystemProxy");
 import { LocalFileSystemProxy } from "../storage/localFileSystemProxy";
 import registerMixins from "../../registerMixins";
 import { appInfo } from "../../common/appInfo";
+import { asin } from "snapsvg";
 
 registerMixins();
 
@@ -25,6 +26,7 @@ describe("TFRecords Json Export Provider", () => {
         "asset-3": MockFactory.createTestAsset("3", AssetState.Visited),
         "asset-4": MockFactory.createTestAsset("4", AssetState.NotVisited),
     };
+    baseTestProject.allAssets = _.values(baseTestProject.assets);
     baseTestProject.sourceConnection = MockFactory.createTestConnection("test", "localFileSystemProxy");
     baseTestProject.targetConnection = MockFactory.createTestConnection("test", "localFileSystemProxy");
 

--- a/src/providers/export/vottJson.test.ts
+++ b/src/providers/export/vottJson.test.ts
@@ -34,6 +34,7 @@ describe("VoTT Json Export Provider", () => {
             },
         },
     };
+    testProject.allAssets = _.values(testProject.assets);
 
     const expectedFileName = "vott-json-export/" + testProject.name.replace(" ", "-") + constants.exportFileExtension;
 

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -175,7 +175,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     <div>
                         <EditorFooter
                             displayHotKeys={true}
-                            tags={this.state.project.tags}
+                            tags={this.props.project.tags}
                             onTagsChanged={this.onFooterChange}
                             onTagClicked={this.onTagClicked}
                             onCtrlTagClicked={this.onCtrlTagClicked}

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -113,9 +113,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         // Navigating directly to the page via URL (ie, http://vott/projects/a1b2c3dEf/edit) sets the default state
         // before props has been set, this updates the project and additional settings to be valid once props are
         // retrieved.
-        if (!this.state.project && this.state.project) {
+        if (this.state.project !== this.props.project) {
             this.setState({
-                project: this.state.project,
+                project: this.props.project,
                 additionalSettings: { videoSettings: (this.state.project) ? this.state.project.videoSettings : null },
             });
         }
@@ -440,8 +440,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
         this.setState({
             assets: rootAssets,
-            project: {...this.state.project,
-                allAssetsIds: rootAssets.map((asset) => asset.id)},
+            project: {...this.state.project, allAssets: rootAssets},
         }, async () => {
             if (rootAssets.length > 0) {
                 await this.selectAsset(lastVisited ? lastVisited : rootAssets[0]);

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -124,5 +124,5 @@ export default function registerToolbar() {
         group: ToolbarItemGroup.Project,
         type: ToolbarItemType.Action,
         accelerators: ["Ctrl+e", "Ctrl+E"],
-    });
+    }, ExportProject);
 }


### PR DESCRIPTION
- Add allAssets list to project and persist on project metadata
- Update state.project from props.project in editorPage
- Use state.project to save and export project
- Differentiate source list when exporting All VS Visited/Tagged
- Re-add exportProject to toolbar
- Update different test

FIX bug #AB17365