### PR TITLE
feature: display project metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6999,7 +6999,8 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -7017,11 +7018,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -7034,15 +7037,18 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -7145,7 +7151,8 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -7155,6 +7162,7 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -7167,17 +7175,20 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -7194,6 +7205,7 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -7266,7 +7278,8 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -7276,6 +7289,7 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -7351,7 +7365,8 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -7381,6 +7396,7 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -7398,6 +7414,7 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -7436,11 +7453,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 }
             }
         },

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -92,6 +92,16 @@ export const english: IAppStrings = {
             saveSuccess: "Successfully saved ${project.name} project settings",
         },
     },
+    projectMetrics: {
+        title: "Project Metrics",
+        sourceAssetsCount: "Number of source assets",
+        visitedAssetsCount: "Number of visited assets",
+        taggedAssetsCount: "Number of tagged assets",
+        regionsCount: "Number of regions drawn",
+        tagCategories: "Number of tag categories",
+        tagCount: "Per tag totals (number of instances of that tag)",
+        averageTagPerTaggedAsset: "Average tags per tagged asset",
+    },
     tags: {
         title: "Tags",
         placeholder: "Add new tag",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -93,6 +93,16 @@ export const spanish: IAppStrings = {
             saveSuccess: "Guardado correctamente ${project.name} configuración del proyecto",
         },
     },
+    projectMetrics: {
+        title: "Métricas del Proyecto",
+        sourceAssetsCount: "Número de activos de origen",
+        visitedAssetsCount: "Número de bienes visitados",
+        taggedAssetsCount: "Número de activos etiquetados",
+        regionsCount: "Número de regiones dibujadas",
+        tagCategories: "Número de categorías de etiquetas",
+        tagCount: "Totales por etiqueta (número de instancias de esa etiqueta)",
+        averageTagPerTaggedAsset: "Etiquetas promedio por activo etiquetado",
+    },
     tags: {
         title: "Etiquetas",
         placeholder: "Agregar nuevo etiqueta",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -96,7 +96,7 @@ export const spanish: IAppStrings = {
     projectMetrics: {
         title: "Métricas del Proyecto",
         sourceAssetsCount: "Número de activos de origen",
-        visitedAssetsCount: "Número de bienes visitados",
+        visitedAssetsCount: "Número de activos visitados",
         taggedAssetsCount: "Número de activos etiquetados",
         regionsCount: "Número de regiones dibujadas",
         tagCategories: "Número de categorías de etiquetas",

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -437,7 +437,7 @@ export default class MockFactory {
      */
     public static createTestTag(name: string = "1"): ITag {
         return {
-            name: `Tag-${name}`,
+            name: `Tag ${name}`,
             color: MockFactory.randomColor(),
         };
     }

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -249,8 +249,9 @@ export default class MockFactory {
     /**
      * Creates fake IProject
      * @param name Name of project. project.id = `project-${name}` and project.name = `Project ${name}`
+     * @param tagCount number of tags to create for project
      */
-    public static createTestProject(name: string = "test"): IProject {
+    public static createTestProject(name: string = "test", tagCount: number = 5): IProject {
         const connection = MockFactory.createTestConnection(name);
 
         return {
@@ -262,7 +263,7 @@ export default class MockFactory {
             exportFormat: MockFactory.exportFormat(),
             sourceConnection: connection,
             targetConnection: connection,
-            tags: MockFactory.createTestTags(),
+            tags: MockFactory.createTestTags(tagCount),
             videoSettings: MockFactory.createVideoSettings(),
             autoSave: true,
         };
@@ -436,7 +437,7 @@ export default class MockFactory {
      */
     public static createTestTag(name: string = "1"): ITag {
         return {
-            name: `Tag ${name}`,
+            name: `Tag-${name}`,
             color: MockFactory.randomColor(),
         };
     }
@@ -683,8 +684,9 @@ export default class MockFactory {
     /**
      * Creates a test region with the optional specified id
      * @param id The id to assign to the region
+     * @param tags the tags used in this region
      */
-    public static createTestRegion(id = null): IRegion {
+    public static createTestRegion(id = null, tags: string[] = []): IRegion {
         const origin = {
             x: randomIntInRange(0, 1024),
             y: randomIntInRange(0, 768),
@@ -708,7 +710,7 @@ export default class MockFactory {
                 { x: origin.x, y: origin.y + size.height }, // Bottom Left
                 { x: origin.x + size.width, y: origin.y + size.height }, // Bottom Right
             ],
-            tags: [],
+            tags,
             type: RegionType.Rectangle,
         };
     }
@@ -1020,4 +1022,5 @@ export default class MockFactory {
                 return StorageType.Other;
         }
     }
+
 }

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -94,6 +94,16 @@ export interface IAppStrings {
             saveSuccess: string;
         },
     };
+    projectMetrics: {
+        title: string;
+        sourceAssetsCount: string;
+        visitedAssetsCount: string;
+        taggedAssetsCount: string;
+        regionsCount: string;
+        tagCategories: string;
+        tagCount: string;
+        averageTagPerTaggedAsset: string;
+    };
     tags: {
         title: string;
         placeholder: string;

--- a/src/providers/export/tensorFlowPascalVOC.test.ts
+++ b/src/providers/export/tensorFlowPascalVOC.test.ts
@@ -138,17 +138,17 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 4.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
 
@@ -190,9 +190,9 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 3.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
 
@@ -231,17 +231,17 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 2.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
     });

--- a/src/providers/export/tensorFlowPascalVOC.test.ts
+++ b/src/providers/export/tensorFlowPascalVOC.test.ts
@@ -138,17 +138,17 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 4.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
 
@@ -190,9 +190,9 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 3.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
 
@@ -231,17 +231,17 @@ describe("TFPascalVOC Json Export Provider", () => {
                 .toBeGreaterThanOrEqual(0);
             expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/Annotations/Asset 2.xml")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_val.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_val.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-0_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 0_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-1_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 1_train.txt")))
                 .toBeGreaterThanOrEqual(0);
-            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag-2_train.txt")))
+            expect(writeTextFileCalls.findIndex((args) => args[0].endsWith("/ImageSets/Main/Tag 2_train.txt")))
                 .toBeGreaterThanOrEqual(0);
         });
     });

--- a/src/react/components/pages/projectSettings/projectMetrics.test.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.test.tsx
@@ -59,10 +59,7 @@ describe("Project metrics page", () => {
             // 4 tag categories, 8 tagged asset
             const assetCountPerTag = 2;
 
-            const tags = defaultProject.tags;
-            const tagName = tags[0].name;
-
-            const tagCount = wrapper.find(`.${tagName}-count`);
+            const tagCount = wrapper.find(".Tag-0");
             expect(tagCount.text()).toEqual(assetCountPerTag.toString());
         });
 
@@ -75,6 +72,34 @@ describe("Project metrics page", () => {
         it("correctly calculate visited asset count", async () => {
             const visitedAssetCount = wrapper.find(".visited-asset-count");
             expect(visitedAssetCount.text()).toEqual("2");
+        });
+    });
+
+    describe("tag name has dash", () => {
+        beforeEach(async () => {
+            setUpMockAssetService(testAssets);
+
+            const project = {
+                ...defaultProject,
+                tags: [
+                    {
+                        ...defaultProject.tags[0],
+                        name: `Tag-0`,
+                    },
+                ],
+            };
+
+            wrapper = createComponent({
+                project,
+            });
+
+            await MockFactory.flushUi();
+            wrapper.update();
+        });
+
+        it("generate the right span class name ", async () => {
+            const tagCount = wrapper.find(".Tag-0");
+            expect(tagCount).toHaveLength(1);
         });
     });
 
@@ -144,4 +169,5 @@ describe("Project metrics page", () => {
             />,
         );
     };
-});
+})
+;

--- a/src/react/components/pages/projectSettings/projectMetrics.test.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.test.tsx
@@ -1,0 +1,147 @@
+import { mount, ReactWrapper } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import MockFactory from "../../../../common/mockFactory";
+import ProjectMetrics, { IProjectMetricsProps, IProjectMetricsState } from "./projectMetrics";
+import _ from "lodash";
+
+import { AssetState } from "../../../../models/applicationState";
+import { AssetService } from "../../../../services/assetService";
+import * as packageJson from "../../../../../package.json";
+
+describe("Project metrics page", () => {
+
+    let wrapper: ReactWrapper<IProjectMetricsProps, IProjectMetricsState> = null;
+
+    const testAssetCount = 10;
+    const testAssets = MockFactory.createTestAssets(testAssetCount);
+
+    const defaultTagCount = 4;
+    const skeletonProject = MockFactory.createTestProject("TestProject", defaultTagCount);
+    const defaultProject = {
+        ...skeletonProject,
+        assets: _.keyBy(testAssets, (asset) => asset.id),
+    };
+
+    describe("regular project", () => {
+        beforeEach(async () => {
+            setUpMockAssetService(testAssets);
+
+            wrapper = createComponent({
+                project: defaultProject,
+            });
+
+            await MockFactory.flushUi();
+            wrapper.update();
+        });
+
+        it("calculates categories count", async () => {
+            const root = wrapper.find(".tag-categories");
+
+            const tagCategoriesCount = root.find(".count");
+            expect(tagCategoriesCount.text()).toEqual(defaultTagCount.toString());
+
+            const tagList = root.find(".list").find("li");
+            expect(tagList).toHaveLength(defaultTagCount);
+        });
+
+        it("calculates source asset count", async () => {
+            const sourceAssetCount = wrapper.find(".source-asset-count");
+            expect(sourceAssetCount.text()).toEqual(testAssetCount.toString());
+        });
+
+        it("calculate tagged asset count", async () => {
+            const taggedAssetCount = wrapper.find(".tagged-asset-count");
+            expect(taggedAssetCount.text()).toEqual("8");
+        });
+
+        it("calculate per tag total", async () => {
+            // 4 tag categories, 8 tagged asset
+            const assetCountPerTag = 2;
+
+            const tags = defaultProject.tags;
+            const tagName = tags[0].name;
+
+            const tagCount = wrapper.find(`.${tagName}-count`);
+            expect(tagCount.text()).toEqual(assetCountPerTag.toString());
+        });
+
+        it("correctly calculate average tags count", async () => {
+            // 8 tagged asset, each one has one tag
+            const avgTagCount = wrapper.find(".average-tag-count");
+            expect(avgTagCount.text()).toEqual("1");
+        });
+
+        it("correctly calculate visited asset count", async () => {
+            const visitedAssetCount = wrapper.find(".visited-asset-count");
+            expect(visitedAssetCount.text()).toEqual("2");
+        });
+    });
+
+    describe("project has no tags", () => {
+        beforeEach(async () => {
+            setUpMockAssetService(testAssets);
+
+            const project = {
+                ...defaultProject,
+                tags: [],
+            };
+
+            wrapper = createComponent({
+                project,
+            });
+
+            await MockFactory.flushUi();
+            wrapper.update();
+        });
+
+        it("tag categories count is 0", async () => {
+            const root = wrapper.find(".tag-categories");
+
+            const tagCategoriesCount = root.find(".count");
+            expect(tagCategoriesCount.text()).toEqual("0");
+
+            const tagList = root.find(".list").find("#li");
+            expect(tagList).toHaveLength(0);
+        });
+    });
+
+    const setUpMockAssetService = (testAssets = []) => {
+        const mockAssetService = AssetService as jest.Mocked<typeof AssetService>;
+        mockAssetService.prototype.getAssets = jest.fn(() => Promise.resolve(testAssets));
+
+        const testAssetsMetadata = _.map(testAssets, (asset, index: number) => {
+            const tagIndex = index % defaultTagCount;
+            console.log(tagIndex);
+            const tags = [defaultProject.tags[tagIndex].name];
+
+            const state = index % 5 === 0 ? AssetState.Visited : AssetState.Tagged;
+            const regions = state === AssetState.Visited ? [] : [MockFactory.createTestRegion(asset.id, tags)];
+            return {
+                asset: {
+                    ...asset,
+                    state,
+                },
+                regions,
+                version: packageJson.version,
+            };
+        });
+
+        mockAssetService.prototype.getAssetMetadata = jest.fn((asset) => {
+            const item = _.find(
+                testAssetsMetadata,
+                (metadata) => metadata.asset.id === asset.id,
+            );
+
+            return Promise.resolve(item);
+        });
+    };
+
+    const createComponent = (props: IProjectMetricsProps): ReactWrapper<IProjectMetricsProps, IProjectMetricsState> => {
+        return mount(
+            <ProjectMetrics
+                {...props}
+            />,
+        );
+    };
+});

--- a/src/react/components/pages/projectSettings/projectMetrics.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.tsx
@@ -55,10 +55,11 @@ export default class ProjectMetrics extends React.Component<IProjectMetricsProps
         const tagsMap = this.getTagsCount();
         const renderTagCount = tags.map((tag) => {
             const tagName = tag.name;
+            const normalizedTagName = tagName.split(" ").join("-");
             return (
                 <li>
                     <b>{tagName}: </b>
-                    <span className={tagName + "-count " + badgeCSS}>
+                    <span className={normalizedTagName + " " + badgeCSS}>
                         {tagsMap.get(tagName) || 0}
                     </span>
                 </li>

--- a/src/react/components/pages/projectSettings/projectMetrics.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.tsx
@@ -1,0 +1,261 @@
+import React from "react";
+import { FormValidation } from "react-jsonschema-form";
+import { AssetState, IAsset, IAssetMetadata, IProject, IRegion } from "../../../../models/applicationState";
+import "vott-react/dist/css/tagsInput.css";
+import _ from "lodash";
+import { AssetService } from "../../../../services/assetService";
+import { strings } from "../../../../common/strings";
+
+/**
+ * Required properties for Project Metrics
+ * @member project - Current project to fill metrics table
+ */
+export interface IProjectMetricsProps {
+    project: IProject;
+}
+
+export interface IProjectMetricsState {
+    loading: boolean;
+    sourceAssets: IAsset[];
+    projectAssetsMetadata: IAssetMetadata[];
+}
+
+/**
+ * @name - Project Form
+ * @description -
+ */
+export default class ProjectMetrics extends React.Component<IProjectMetricsProps, IProjectMetricsState> {
+    public state = {
+        loading: true,
+        sourceAssets: [],
+        projectAssetsMetadata: [],
+    };
+
+    public async componentDidMount() {
+        this.setState({
+            loading: true,
+        });
+
+        await this.getAssetsAndMetadata();
+    }
+
+    public render() {
+        if (this.state.loading) {
+            console.log("Waiting for data");
+            return <h2> Loading...</h2>;
+        }
+
+        const badgeCSS = "badge badge-light badge-pill float-center";
+
+        const tags = this.props.project.tags || [];
+        const renderTagCategories = tags.map((item) => {
+            return (<li>{item.name}</li>);
+        });
+
+        const tagsMap = this.getTagsCount();
+        const renderTagCount = tags.map((tag) => {
+            const tagName = tag.name;
+            return (
+                <li>
+                    <b>{tagName}: </b>
+                    <span className={tagName + "-count " + badgeCSS}>
+                        {tagsMap.get(tagName) || 0}
+                    </span>
+                </li>
+            );
+        });
+
+        return (
+            <div className="project-settings-page-metrics p-3 bg-lighter-1">
+                <h3>
+                    <i className="fas fa-chart-bar fa-1x"/>
+                    <span className="px-2">
+                        {strings.projectMetrics.title}
+                    </span>
+                </h3>
+                <ul className="list-group list-group-flush m-3">
+                    <li className="list-group-item">
+                        <b>{strings.projectMetrics.sourceAssetsCount}   </b>
+                        <span
+                            className={"source-asset-count " + badgeCSS}>
+                            {this.getSourceAssetCount()}
+                        </span>
+                    </li>
+                    <li className="list-group-item">
+                        <b>{strings.projectMetrics.visitedAssetsCount}   </b>
+                        <span
+                            className={"visited-asset-count " + badgeCSS}>
+                            {this.getVisitedAssetsCount()}
+                        </span>
+                    </li>
+                    <li className="list-group-item">
+                        <b>{strings.projectMetrics.taggedAssetsCount}   </b>
+                        <span
+                            className={"tagged-asset-count " + badgeCSS}>
+                            {this.getTaggedAssetCount()}
+                        </span>
+                    </li>
+                    <li className="list-group-item">
+                        <b>{strings.projectMetrics.regionsCount}   </b>
+                        <span className={"regions-count " + badgeCSS}>
+                              {this.getRegionsCount()}
+                        </span>
+                    </li>
+                    <li className="list-group-item tag-categories">
+                        <h5>{strings.projectMetrics.tagCategories}
+                            <span className={"count " + badgeCSS}>
+                                {this.getTagCategoriesCount()}
+                            </span>
+                        </h5>
+                        <ul className="list">{renderTagCategories}</ul>
+                    </li>
+                    <li className="list-group-item">
+                        <h5>{strings.projectMetrics.tagCount}   </h5>
+                        <span className="tags-map">
+                            <ul>{renderTagCount}</ul>
+                        </span>
+                    </li>
+                    <li className="list-group-item">
+                        <b>{strings.projectMetrics.averageTagPerTaggedAsset}   </b>
+                        <span
+                            className={"average-tag-count " + badgeCSS}>
+                            {this.getAverageTagCount()}
+                        </span>
+                    </li>
+                </ul>
+            </div>
+        );
+    }
+
+    private async getAssetsAndMetadata() {
+        const assetService = new AssetService(this.props.project);
+        const sourceAssets = await assetService.getAssets();
+
+        const assetsMap = this.props.project.assets;
+        let projectAssetsMetadata = [];
+        if (assetsMap) {
+            const assets = _.values(assetsMap);
+            const temp = assets.map((a) => assetService.getAssetMetadata(a));
+            projectAssetsMetadata = await Promise.all(temp);
+        }
+
+        this.setState({
+            loading: false,
+            sourceAssets,
+            projectAssetsMetadata,
+        });
+    }
+
+    /**
+     * Count the number of tagged images or video frames
+     */
+    private getTaggedAssetCount = () => {
+        const metadata = this.state.projectAssetsMetadata;
+
+        const taggedAssets = _.filter(metadata,
+            (m) => {
+                // ignore video asset root container
+                return m.asset.state === AssetState.Tagged && m.regions.length > 0;
+            });
+
+        return taggedAssets.length;
+    }
+
+    /**
+     * Count the avg number of tags per image or video frame
+     */
+    private getAverageTagCount = () => {
+        const taggedAssetCount = this.getTaggedAssetCount();
+
+        if (taggedAssetCount === 0) {
+            return 0;
+        }
+
+        const tags = this.getAllTags();
+        return tags.length / taggedAssetCount;
+    }
+
+    /**
+     * The number of visited image or video frames
+     */
+    private getVisitedAssetsCount = () => {
+        const metadata = this.state.projectAssetsMetadata;
+
+        const visitedAssets = _.filter(metadata, (m) => {
+            return m.asset.state === AssetState.Visited;
+        });
+
+        return visitedAssets.length;
+    }
+
+    /**
+     * Total regions drawn on all assets
+     */
+    private getRegionsCount = () => {
+        const regions = this.getRegions();
+        return regions.length;
+    }
+
+    /**
+     * Total number of source assets in the project
+     *   Note: video frames are not counted, only the video container
+     */
+    private getSourceAssetCount = () => {
+        const assets = this.state.sourceAssets;
+        return assets.length;
+    }
+
+    /**
+     * The number of tag categories in the project
+     */
+    private getTagCategoriesCount = (): number => {
+        const tags = this.props.project.tags;
+        return tags ? tags.length : 0;
+    }
+
+    /**
+     * a map of asset count per tag
+     */
+    private getTagsCount = () => {
+        const tags = this.getAllTags();
+
+        const map = new Map();
+        tags.forEach((t) => {
+            const cur = map.get(t) || 0;
+            map.set(t, cur + 1);
+        });
+
+        return map;
+    }
+
+    /**
+     * retrieve the list of regions drawn
+     */
+    private getRegions = (): IRegion[] => {
+        const assetsMetadata = this.state.projectAssetsMetadata;
+
+        // find all assets with non-zero regions, extract regions
+        const regions = [];
+        assetsMetadata.forEach((m) => {
+            if (m.regions.length > 0) {
+                regions.push((m.regions));
+            }
+        });
+
+        return _.flatten(regions);
+    }
+
+    /**
+     * retrieve the list of tags assigned
+     */
+    private getAllTags = () => {
+        const regions = this.getRegions();
+
+        const tags = [];
+        regions.forEach((r) => {
+            tags.push(r.tags);
+        });
+
+        return _.flatten(tags);
+    }
+}

--- a/src/react/components/pages/projectSettings/projectMetrics.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.tsx
@@ -75,31 +75,32 @@ export default class ProjectMetrics extends React.Component<IProjectMetricsProps
                 </h3>
                 <ul className="list-group list-group-flush m-3">
                     <li className="list-group-item">
-                        <b>{strings.projectMetrics.sourceAssetsCount}   </b>
-                        <span
-                            className={"source-asset-count " + badgeCSS}>
-                            {this.getSourceAssetCount()}
-                        </span>
+                        <h5>{strings.projectMetrics.sourceAssetsCount}
+                            <span className={"source-asset-count " + badgeCSS}>
+                                {this.getSourceAssetCount()}
+                            </span>
+                        </h5>
                     </li>
                     <li className="list-group-item">
-                        <b>{strings.projectMetrics.visitedAssetsCount}   </b>
-                        <span
-                            className={"visited-asset-count " + badgeCSS}>
-                            {this.getVisitedAssetsCount()}
-                        </span>
+                        <h5>{strings.projectMetrics.visitedAssetsCount}
+                            <span className={"visited-asset-count " + badgeCSS}>
+                                {this.getVisitedAssetsCount()}
+                            </span>
+                        </h5>
                     </li>
                     <li className="list-group-item">
-                        <b>{strings.projectMetrics.taggedAssetsCount}   </b>
-                        <span
-                            className={"tagged-asset-count " + badgeCSS}>
-                            {this.getTaggedAssetCount()}
-                        </span>
+                        <h5>{strings.projectMetrics.taggedAssetsCount}
+                            <span className={"tagged-asset-count " + badgeCSS}>
+                                {this.getTaggedAssetCount()}
+                            </span>
+                        </h5>
                     </li>
                     <li className="list-group-item">
-                        <b>{strings.projectMetrics.regionsCount}   </b>
-                        <span className={"regions-count " + badgeCSS}>
-                              {this.getRegionsCount()}
-                        </span>
+                        <h5>{strings.projectMetrics.regionsCount}
+                            <span className={"regions-count " + badgeCSS}>
+                                {this.getRegionsCount()}
+                            </span>
+                        </h5>
                     </li>
                     <li className="list-group-item tag-categories">
                         <h5>{strings.projectMetrics.tagCategories}
@@ -116,11 +117,11 @@ export default class ProjectMetrics extends React.Component<IProjectMetricsProps
                         </span>
                     </li>
                     <li className="list-group-item">
-                        <b>{strings.projectMetrics.averageTagPerTaggedAsset}   </b>
-                        <span
-                            className={"average-tag-count " + badgeCSS}>
-                            {this.getAverageTagCount()}
-                        </span>
+                        <h5>{strings.projectMetrics.averageTagPerTaggedAsset}
+                            <span className={"average-tag-count " + badgeCSS}>
+                                {this.getAverageTagCount()}
+                            </span>
+                        </h5>
                     </li>
                 </ul>
             </div>

--- a/src/react/components/pages/projectSettings/projectSettingsPage.scss
+++ b/src/react/components/pages/projectSettings/projectSettingsPage.scss
@@ -1,0 +1,14 @@
+.project-settings-page {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+
+    &-settings {
+        flex-grow: 1;
+    }
+
+    &-metrics {
+        align-content: center;
+        align-items: center;
+    }
+}

--- a/src/react/components/pages/projectSettings/projectSettingsPage.test.tsx
+++ b/src/react/components/pages/projectSettings/projectSettingsPage.test.tsx
@@ -10,10 +10,19 @@ jest.mock("../../../../services/projectService");
 import ProjectService from "../../../../services/projectService";
 import { IAppSettings } from "../../../../models/applicationState";
 
+jest.mock("./projectMetrics", () => () => {
+        return (
+            <div className="project-settings-page-metrics">
+                Dummy Project Metrics
+            </div>
+        );
+    },
+);
+
 describe("Project settings page", () => {
     let projectServiceMock: jest.Mocked<typeof ProjectService> = null;
 
-    function createCompoent(store, props: IProjectSettingsPageProps): ReactWrapper {
+    function createComponent(store, props: IProjectSettingsPageProps): ReactWrapper {
         return mount(
             <Provider store={store}>
                 <Router>
@@ -25,7 +34,7 @@ describe("Project settings page", () => {
 
     beforeEach(() => {
         projectServiceMock = ProjectService as jest.Mocked<typeof ProjectService>;
-        projectServiceMock.prototype.load = jest.fn((project) => ({ ...project }));
+        projectServiceMock.prototype.load = jest.fn((project) => ({...project}));
     });
 
     it("Form submission calls save project action", (done) => {
@@ -35,7 +44,7 @@ describe("Project settings page", () => {
 
         projectServiceMock.prototype.save = jest.fn((project) => Promise.resolve(project));
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         wrapper.find("form").simulate("submit");
 
         setImmediate(() => {
@@ -54,7 +63,7 @@ describe("Project settings page", () => {
         const props = MockFactory.projectSettingsProps();
         const saveProjectSpy = jest.spyOn(props.projectActions, "saveProject");
 
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         wrapper.setProps({
             form: {
                 name: project.name,
@@ -79,7 +88,7 @@ describe("Project settings page", () => {
         const initialState = MockFactory.initialState();
 
         // New Project should not have id or security token set by default
-        const project = { ...initialState.recentProjects[0] };
+        const project = {...initialState.recentProjects[0]};
         project.id = null;
         project.name = "Brand New Project";
         project.securityToken = "";
@@ -93,7 +102,7 @@ describe("Project settings page", () => {
         const saveAppSettingsSpy = jest.spyOn(props.applicationActions, "saveAppSettings");
 
         projectServiceMock.prototype.save = jest.fn((project) => Promise.resolve(project));
-        const wrapper = createCompoent(store, props);
+        const wrapper = createComponent(store, props);
         wrapper.find("form").simulate("submit");
 
         setImmediate(() => {
@@ -109,6 +118,31 @@ describe("Project settings page", () => {
             });
 
             done();
+        });
+    });
+
+    it("render ProjectMetrics", () => {
+        const store = createReduxStore(MockFactory.initialState());
+        const props = MockFactory.projectSettingsProps();
+
+        const wrapper = createComponent(store, props);
+        const projectMetrics = wrapper.find(".project-settings-page-metrics");
+        expect(projectMetrics).toHaveLength(1);
+    });
+
+    describe("project does not exists", () => {
+        it("does not render ProjectMetrics", () => {
+            const initialState = MockFactory.initialState();
+
+            // Override currentProject to load the form values
+            initialState.currentProject = null;
+
+            const store = createReduxStore(initialState);
+            const props = MockFactory.projectSettingsProps();
+
+            const wrapper = createComponent(store, props);
+            const projectMetrics = wrapper.find(".project-settings-page-metrics");
+            expect(projectMetrics).toHaveLength(0);
         });
     });
 });

--- a/src/react/components/pages/projectSettings/projectSettingsPage.tsx
+++ b/src/react/components/pages/projectSettings/projectSettingsPage.tsx
@@ -8,6 +8,8 @@ import IProjectActions, * as projectActions from "../../../../redux/actions/proj
 import { IApplicationState, IProject, IConnection, IAppSettings } from "../../../../models/applicationState";
 import IApplicationActions, * as applicationActions from "../../../../redux/actions/applicationActions";
 import { toast } from "react-toastify";
+import "./projectSettingsPage.scss";
+import ProjectMetrics from "./projectMetrics";
 
 /**
  * Properties for Project Settings Page
@@ -63,21 +65,23 @@ export default class ProjectSettingsPage extends React.Component<IProjectSetting
 
     public render() {
         return (
-            <div className="m-3 text-light">
-                <h3>
-                    <i className="fas fa-sliders-h fa-1x"></i>
-                    <span className="px-2">
-                        {strings.projectSettings.title}
-                    </span>
-                </h3>
-                <div className="m-3 text-light">
+            <div className="project-settings-page">
+                <div className="project-settings-page-settings m-3 text-light">
+                    <h3>
+                        <i className="fas fa-sliders-h fa-1x"/>
+                        <span className="px-2">
+                            {strings.projectSettings.title}
+                        </span>
+                    </h3>
                     <ProjectForm
                         project={this.props.project}
                         connections={this.props.connections}
                         appSettings={this.props.appSettings}
                         onSubmit={this.onFormSubmit}
-                        onCancel={this.onFormCancel} />
+                        onCancel={this.onFormCancel}/>
                 </div>
+                {this.props.project &&
+                <ProjectMetrics project={this.props.project}/>}
             </div>
         );
     }
@@ -88,7 +92,7 @@ export default class ProjectSettingsPage extends React.Component<IProjectSetting
         await this.props.applicationActions.ensureSecurityToken(project);
         await this.props.projectActions.saveProject(project);
 
-        toast.success(interpolate(strings.projectSettings.messages.saveSuccess, { project }));
+        toast.success(interpolate(strings.projectSettings.messages.saveSuccess, {project}));
 
         if (isNew) {
             this.props.history.push(`/projects/${this.props.project.id}/edit`);


### PR DESCRIPTION
add a panel inside `Project Settings` page to display relevant project metrics:
1.  number of source assets 
1.  number of tagged assets
1.  number of visited assets
1.  number of regions drawn
1. avg tags per asset
1. number of tags categories in project
1. number of tags in each category

AB#16587

![screen shot 2019-03-01 at 16 24 59](https://user-images.githubusercontent.com/1634185/53673827-c313bb80-3c3e-11e9-92a6-2a14fc4efc27.png)
