### PR TITLE
fix: Don't allow invalid pasting [AB#17353]

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -257,7 +257,7 @@ export const english: IAppStrings = {
     errors: {
         unknown: {
             title: "Unknown Error",
-            message: "The app encounted an unknown error. Please try again.",
+            message: "The app encountered an unknown error. Please try again.",
         },
         projectUploadError: {
             title: "Error Uploading File",
@@ -295,5 +295,9 @@ export const english: IAppStrings = {
             title: "Error importing V1 project",
             message: "There was an error importing the V1 project. Check the project file and try again",
         },
+        pasteRegionTooBigError: {
+            title: "Error pasting region",
+            message: "Region too big for this asset. Try copying another region",
+        }
     },
 };

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -298,6 +298,6 @@ export const english: IAppStrings = {
         pasteRegionTooBigError: {
             title: "Error pasting region",
             message: "Region too big for this asset. Try copying another region",
-        }
+        },
     },
 };

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -300,6 +300,6 @@ export const spanish: IAppStrings = {
         pasteRegionTooBigError: {
             title: "Error al pegar region al activo",
             message: "Hubo un error al pagar el region al activo. Intenta copiar otra region",
-        }
+        },
     },
 };

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -297,5 +297,9 @@ export const spanish: IAppStrings = {
             title: "Error al importar el proyecto V1",
             message: "Hubo un error al importar el proyecto V1. Revisa el archivo del proyecto y vuelve a intentarlo",
         },
+        pasteRegionTooBigError: {
+            title: "Error al pegar region al activo",
+            message: "Hubo un error al pagar el region al activo. Intenta copiar otra region",
+        }
     },
 };

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -266,6 +266,7 @@ export interface IAppStrings {
         securityTokenNotFound: IErrorMetadata,
         canvasError: IErrorMetadata,
         importError: IErrorMetadata,
+        pasteRegionTooBigError: IErrorMetadata,
     };
 }
 

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -46,6 +46,7 @@ export enum ErrorCode {
     SecurityTokenNotFound = "securityTokenNotFound",
     CanvasError = "canvasError",
     V1ImportError = "v1ImportError",
+    PasteRegionTooBigError = "pasteRegionTooBigError",
 }
 
 /**

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Selection/AreaSelector";
 import { RegionType } from "vott-react";
 import MockFactory from "../../../../common/mockFactory";
-import { EditorMode, IAssetMetadata, IRegion } from "../../../../models/applicationState";
+import { EditorMode, IAssetMetadata, IRegion, IAsset } from "../../../../models/applicationState";
 import { AssetPreview, IAssetPreviewProps } from "../../common/assetPreview/assetPreview";
 import Canvas, { ICanvasProps, ICanvasState } from "./canvas";
 import CanvasHelpers from "./canvasHelpers";
@@ -30,8 +30,14 @@ describe("Editor Canvas", () => {
     }
 
     function getAssetMetadata() {
-        return MockFactory.createTestAssetMetadata(
-            MockFactory.createTestAsset(), MockFactory.createTestRegions());
+        const asset: IAsset = {
+            ...MockFactory.createTestAsset(),
+            size: {
+                width: 1600,
+                height: 1200,
+            },
+        };
+        return MockFactory.createTestAssetMetadata(asset, MockFactory.createTestRegions());
     }
 
     function createProps() {

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -137,9 +137,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
     public pasteRegions = async () => {
         const regionsToPaste: IRegion[] = await Clipboard.readObject();
+        const asset = this.state.currentAsset;
         const duplicates = CanvasHelpers.duplicateRegionsAndMove(
             regionsToPaste,
-            this.state.currentAsset.regions,
+            asset.regions,
+            asset.asset.size.width,
+            asset.asset.size.height,
         );
         this.addRegions(duplicates);
     }
@@ -167,7 +170,10 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
     private addRegionsToCanvasTools = (regions: IRegion[]) => {
         for (const region of regions) {
             const regionData = CanvasHelpers.getRegionData(region);
-            const scaledRegionData = this.editor.scaleRegionToFrameSize(regionData);
+            const scaledRegionData = this.editor.scaleRegionToFrameSize(
+                regionData,
+                this.state.currentAsset.asset.size.width,
+                this.state.currentAsset.asset.size.height);
             this.editor.RM.addRegion(
                 region.id,
                 scaledRegionData,

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -76,6 +76,33 @@ describe("Canvas Helpers", () => {
         expect(CanvasHelpers.regionTypeToType(null)).toBeUndefined();
     });
 
+    it("Creates a point array from a bounding box", () => {
+        const boundingBox = {
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+        };
+        expect(CanvasHelpers.fromBoundingBox(boundingBox)).toEqual([
+            {
+                x: 0,
+                y: 0,
+            },
+            {
+                x: 100,
+                y: 0,
+            },
+            {
+                x: 100,
+                y: 100,
+            },
+            {
+                x: 0,
+                y: 100,
+            },
+        ]);
+    });
+
     it("Duplicates and moves a region", () => {
         const regions = MockFactory.createTestRegions();
         const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 1000, 2000);

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -1,6 +1,6 @@
 import CanvasHelpers from "./canvasHelpers";
 import MockFactory from "../../../../common/mockFactory";
-import { RegionType, IRegion } from "../../../../models/applicationState";
+import { RegionType, IRegion, IBoundingBox } from "../../../../models/applicationState";
 import { RegionDataType, RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 import { Point2D } from "vott-ct/lib/js/CanvasTools/Core/Point2D";
 
@@ -94,6 +94,59 @@ describe("Canvas Helpers", () => {
                 };
             }),
         });
+    });
+
+    function expectDefaultDuplication(left, top, width = 100, height = 100) {
+        const regions = MockFactory.createTestRegions();
+        const boundingBox: IBoundingBox = {
+            left,
+            top,
+            width,
+            height,
+        };
+        regions[0] = {
+            ...regions[0],
+            boundingBox,
+            points: CanvasHelpers.fromBoundingBox(boundingBox),
+        };
+        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 1000, 1000);
+        const expectedBoundingBox: IBoundingBox = {
+            ...boundingBox,
+            left: 0,
+            top: 0,
+        };
+        expect(duplicates[0]).toMatchObject({
+            ...regions[0],
+            id: expect.any(String),
+            boundingBox: expectedBoundingBox,
+            points: CanvasHelpers.fromBoundingBox(expectedBoundingBox),
+        });
+    }
+
+    it("Duplicates a region with coordinates out of range into the default location", () => {
+        // Starting coordinates out of range
+        expectDefaultDuplication(1001, 1001);
+        // Starting left out of range
+        expectDefaultDuplication(1001, 0);
+        // Starting right out of range
+        expectDefaultDuplication(0, 1001);
+        // Both width and height put out of range
+        expectDefaultDuplication(999, 999);
+        // Width puts out of range
+        expectDefaultDuplication(999, 0);
+        // Height puts out of range
+        expectDefaultDuplication(0, 999);
+    });
+
+    it("Throws error for region too big", () => {
+        // Both width and height too big
+        expect(() => expectDefaultDuplication(500, 500, 1001, 1001)).toThrowError();
+        // Just width too big
+        expect(() => expectDefaultDuplication(500, 500, 1001, 10)).toThrowError();
+        // Just height too big
+        expect(() => expectDefaultDuplication(500, 500, 10, 1001)).toThrowError();
+        // Neither too big
+        expect(() => expectDefaultDuplication(1001, 1001, 10, 10)).not.toThrowError();
     });
 
     it("Toggles a tag", () => {

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -78,7 +78,7 @@ describe("Canvas Helpers", () => {
 
     it("Duplicates and moves a region", () => {
         const regions = MockFactory.createTestRegions();
-        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions);
+        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 1000, 2000);
         expect(duplicates[0]).toMatchObject({
             ...regions[0],
             id: expect.any(String),

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -184,10 +184,10 @@ export default class CanvasHelpers {
      * @param regions Regions to duplicate
      * @param others Other regions existing in the asset (used to not put region on top of other region)
      */
-    public static duplicateRegionsAndMove = (regions: IRegion[], others: IRegion[]): IRegion[] => {
+    public static duplicateRegionsAndMove = (regions: IRegion[], others: IRegion[], width: number, height: number): IRegion[] => {
         const result: IRegion[] = [];
         for (const region of regions) {
-            const shiftCoordinates = CanvasHelpers.getShiftCoordinates(region.boundingBox, others);
+            const shiftCoordinates = CanvasHelpers.getShiftCoordinates(region.boundingBox, others, width, height);
 
             const newRegion: IRegion = {
                 ...region,
@@ -198,6 +198,34 @@ export default class CanvasHelpers {
             result.push(newRegion);
         }
         return result;
+    }
+
+    public static boundingBoxWithin = (boundingBox: IBoundingBox, width: number, height: number) => {
+        return (
+            (boundingBox.left + boundingBox.width) < width &&
+            (boundingBox.top + boundingBox.height) < height
+        );
+    }
+
+    public static fromBoundingBox = (boundingBox: IBoundingBox):IPoint[] => {
+        return [
+            {
+                x: boundingBox.left,
+                y: boundingBox.top,
+            },
+            {
+                x: boundingBox.left + boundingBox.width,
+                y: boundingBox.top,
+            },
+            {
+                x: boundingBox.left + boundingBox.width,
+                y: boundingBox.top + boundingBox.height,
+            },
+            {
+                x: boundingBox.left,
+                y: boundingBox.top + boundingBox.height,
+            },
+        ]
     }
 
     private static shiftBoundingBox = (boundingBox: IBoundingBox, shiftCoordinates: IPoint): IBoundingBox => {
@@ -217,7 +245,7 @@ export default class CanvasHelpers {
         });
     }
 
-    private static getShiftCoordinates = (boundingBox: IBoundingBox, otherRegions: IRegion[]) => {
+    private static getShiftCoordinates = (boundingBox: IBoundingBox, otherRegions: IRegion[], width: number, height: number): IPoint => {
         let x = boundingBox.left;
         let y = boundingBox.top;
 
@@ -235,10 +263,11 @@ export default class CanvasHelpers {
                 y += CanvasHelpers.pasteMargin;
                 foundRegionAtTarget = false;
             } else {
-                return {
+                const result = {
                     x: x - boundingBox.left,
                     y: y - boundingBox.top,
                 };
+                return result;
             }
         }
     }

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -4,7 +4,8 @@ import { RegionData, RegionDataType } from "vott-ct/lib/js/CanvasTools/Core/Regi
 import { Tag } from "vott-ct/lib/js/CanvasTools/Core/Tag";
 import { TagsDescriptor } from "vott-ct/lib/js/CanvasTools/Core/TagsDescriptor";
 import Guard from "../../../../common/guard";
-import { IBoundingBox, IRegion, ITag, RegionType, IPoint, AppError, ErrorCode } from "../../../../models/applicationState";
+import { IBoundingBox, IRegion, ITag, RegionType,
+    IPoint, AppError, ErrorCode } from "../../../../models/applicationState";
 import { strings } from "../../../../common/strings";
 
 /**
@@ -185,7 +186,8 @@ export default class CanvasHelpers {
      * @param regions Regions to duplicate
      * @param others Other regions existing in the asset (used to not put region on top of other region)
      */
-    public static duplicateRegionsAndMove = (regions: IRegion[], others: IRegion[], width: number, height: number): IRegion[] => {
+    public static duplicateRegionsAndMove =
+            (regions: IRegion[], others: IRegion[], width: number, height: number): IRegion[] => {
         const result: IRegion[] = [];
         for (const region of regions) {
             const shiftCoordinates = CanvasHelpers.getShiftCoordinates(region.boundingBox, others, width, height);
@@ -208,7 +210,7 @@ export default class CanvasHelpers {
         );
     }
 
-    public static fromBoundingBox = (boundingBox: IBoundingBox):IPoint[] => {
+    public static fromBoundingBox = (boundingBox: IBoundingBox): IPoint[] => {
         return [
             {
                 x: boundingBox.left,
@@ -226,7 +228,7 @@ export default class CanvasHelpers {
                 x: boundingBox.left,
                 y: boundingBox.top + boundingBox.height,
             },
-        ]
+        ];
     }
 
     private static shiftBoundingBox = (boundingBox: IBoundingBox, shiftCoordinates: IPoint): IBoundingBox => {
@@ -255,7 +257,8 @@ export default class CanvasHelpers {
         return false;
     }
 
-    private static getShiftCoordinates = (boundingBox: IBoundingBox, otherRegions: IRegion[], width: number, height: number): IPoint => {
+    private static getShiftCoordinates =
+            (boundingBox: IBoundingBox, otherRegions: IRegion[], width: number, height: number): IPoint => {
         let x = boundingBox.left;
         let y = boundingBox.top;
 
@@ -287,13 +290,13 @@ export default class CanvasHelpers {
                     ...boundingBox,
                     left: boundingBox.left + result.x,
                     top: boundingBox.top + result.y,
-                }
+                };
                 if (CanvasHelpers.boundingBoxWithin(tempBoundingBox, width, height)) {
                     return result;
                 } else {
                     x = defaultTargetX;
                     y = defaultTargetY;
-                    if (CanvasHelpers.existsRegionAt(otherRegions, defaultTargetX, defaultTargetY)){
+                    if (CanvasHelpers.existsRegionAt(otherRegions, defaultTargetX, defaultTargetY)) {
                         defaultTargetX += CanvasHelpers.pasteMargin;
                     }
                 }


### PR DESCRIPTION
- Still need to implement tests for most of this
- Scales pasted regions appropriately
- Pastes regions that don't fit to top left and cascades down and to the right
- Throws error if region is too big to be pasted in asset