### PR TITLE
fix: Handle project with no tags while loading regions [AB#17357]

### DIFF
--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -225,9 +225,9 @@ export default class MockFactory {
      * Creates fake IAssetMetadata
      * @param asset Test asset
      */
-    public static createTestAssetMetadata(asset: IAsset, regions?: IRegion[]): IAssetMetadata {
+    public static createTestAssetMetadata(asset?: IAsset, regions?: IRegion[]): IAssetMetadata {
         return {
-            asset,
+            asset: asset || MockFactory.createTestAsset(),
             regions: regions || [],
             version: appInfo.version,
         };

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -122,6 +122,26 @@ describe("Editor Canvas", () => {
         expect(wrapper.state().contentSource).toEqual(expect.any(HTMLImageElement));
     });
 
+    it("loads asset with regions even if project has no tags", () => {
+        const cProps = createProps().canvas;
+        const assetMetadata = {
+            ...MockFactory.createTestAssetMetadata(),
+            regions: MockFactory.createTestRegions(),
+        };
+
+        const wrapper = createComponent({
+            ...cProps,
+            project: {
+                ...MockFactory.createTestProject(),
+                tags: null,
+            },
+            selectedAsset: assetMetadata,
+        });
+        const canvas = wrapper.instance() as Canvas;
+        expect(wrapper.state().currentAsset).toEqual(assetMetadata);
+        expect(() => canvas.updateCanvasToolsRegions()).not.toThrowError();
+    });
+
     it("canvas content source is updated when asset is deactivated", () => {
         const wrapper = createComponent();
         const contentSource = document.createElement("img");

--- a/src/react/components/pages/editorPage/canvasHelpers.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.ts
@@ -128,7 +128,9 @@ export default class CanvasHelpers {
      * @param region IRegion from Canvas
      */
     public static getTagsDescriptor(projectTags: ITag[], region: IRegion): TagsDescriptor {
-        Guard.null(projectTags);
+        if (!projectTags || !projectTags.length) {
+            return null;
+        }
         Guard.null(region);
 
         const tags = region.tags


### PR DESCRIPTION
This handles an error where we set a guard to prevent non-null tags when getting the TagsDescriptor. CanvasTools expects a `null` when creating a region with no tags, so it's fine to just return null if there are no tags rather than raising an exception.

Resolves [AB#17357]