### PR TITLE
fix: remove "All assets" from export options dropdown

### DIFF
--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -165,6 +165,11 @@ export interface IConnection {
     providerOptions: IProviderOptions | ISecureString;
 }
 
+/**
+ * @name - Export Provider Options
+ * @description - options defining the type of asset to export
+ * @member assetState - export asset with the following state
+ */
 export interface IExportProviderOptions extends IProviderOptions {
     assetState: ExportAssetState;
 }

--- a/src/providers/export/azureCustomVision.json
+++ b/src/providers/export/azureCustomVision.json
@@ -11,13 +11,11 @@
             "title": "${strings.export.providers.common.properties.assetState.title}",
             "description": "${strings.export.providers.common.properties.assetState.description}",
             "enum": [
-                "all",
                 "visited",
                 "tagged"
             ],
-            "default": "all",
+            "default": "visited",
             "enumNames": [
-                "${strings.export.providers.common.properties.assetState.options.all}",
                 "${strings.export.providers.common.properties.assetState.options.visited}",
                 "${strings.export.providers.common.properties.assetState.options.tagged}"
             ]

--- a/src/providers/export/tensorFlowPascalVOC.json
+++ b/src/providers/export/tensorFlowPascalVOC.json
@@ -7,13 +7,11 @@
             "title": "${strings.export.providers.common.properties.assetState.title}",
             "description": "${strings.export.providers.common.properties.assetState.description}",
             "enum": [
-                "all",
                 "visited",
                 "tagged"
             ],
-            "default": "all",
+            "default": "visited",
             "enumNames": [
-                "${strings.export.providers.common.properties.assetState.options.all}",
                 "${strings.export.providers.common.properties.assetState.options.visited}",
                 "${strings.export.providers.common.properties.assetState.options.tagged}"
             ]

--- a/src/providers/export/tensorFlowRecords.json
+++ b/src/providers/export/tensorFlowRecords.json
@@ -7,13 +7,11 @@
             "title": "${strings.export.providers.common.properties.assetState.title}",
             "description": "${strings.export.providers.common.properties.assetState.description}",
             "enum": [
-                "all",
                 "visited",
                 "tagged"
             ],
-            "default": "all",
+            "default": "visited",
             "enumNames": [
-                "${strings.export.providers.common.properties.assetState.options.all}",
                 "${strings.export.providers.common.properties.assetState.options.visited}",
                 "${strings.export.providers.common.properties.assetState.options.tagged}"
             ]

--- a/src/providers/export/vottJson.json
+++ b/src/providers/export/vottJson.json
@@ -7,13 +7,11 @@
             "title": "${strings.export.providers.common.properties.assetState.title}",
             "description": "${strings.export.providers.common.properties.assetState.description}",
             "enum": [
-                "all",
                 "visited",
                 "tagged"
             ],
-            "default": "all",
+            "default": "visited",
             "enumNames": [
-                "${strings.export.providers.common.properties.assetState.options.all}",
                 "${strings.export.providers.common.properties.assetState.options.visited}",
                 "${strings.export.providers.common.properties.assetState.options.tagged}"
             ]

--- a/src/react/components/pages/export/exportForm.test.tsx
+++ b/src/react/components/pages/export/exportForm.test.tsx
@@ -88,7 +88,7 @@ describe("Export Form Component", () => {
         const defaultExportSettings: IExportFormat = {
             providerType: "vottJson",
             providerOptions: {
-                assetState: ExportAssetState.All,
+                assetState: ExportAssetState.Visited,
             },
         };
 

--- a/src/react/components/pages/export/exportForm.tsx
+++ b/src/react/components/pages/export/exportForm.tsx
@@ -160,7 +160,7 @@ export default class ExportForm extends React.Component<IExportFormProps, IExpor
 
         const formData = { ...exportFormat };
         if (resetProviderOptions) {
-            formData.providerOptions = { assetState: ExportAssetState.All };
+            formData.providerOptions = { assetState: ExportAssetState.Visited };
         }
         formData.providerType = providerType;
 

--- a/src/react/components/pages/export/exportPage.tsx
+++ b/src/react/components/pages/export/exportPage.tsx
@@ -43,7 +43,7 @@ export default class ExportPage extends React.Component<IExportPageProps> {
     private emptyExportFormat: IExportFormat = {
         providerType: "",
         providerOptions: {
-            assetState: ExportAssetState.All,
+            assetState: ExportAssetState.Visited,
         },
     };
 


### PR DESCRIPTION
"all assets" doesn't currently export all assets,
removing it so it doesn't cause confusion.

We will add back this support once we have a working fix.

AB#17461