### PR TITLE
feat: Clear Regions updates [AB#17269]

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -184,6 +184,12 @@ export const english: IAppStrings = {
             },
         },
         assetError: "Unable to display asset",
+        canvas: {
+            clearRegions: {
+                title: "Clear Regions",
+                confirmation: "Are you sure you want to clear all regions?",
+            },
+        },
     },
     export: {
         title: "Export",

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -185,9 +185,9 @@ export const english: IAppStrings = {
         },
         assetError: "Unable to display asset",
         canvas: {
-            clearRegions: {
-                title: "Clear Regions",
-                confirmation: "Are you sure you want to clear all regions?",
+            removeAllRegions: {
+                title: "Remove All Regions",
+                confirmation: "Are you sure you want to remove all regions?",
             },
         },
     },

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -185,6 +185,12 @@ export const spanish: IAppStrings = {
             },
         },
         assetError: "No se puede mostrar el activo",
+        canvas: {
+            clearRegions: {
+                title: "Borrar Regiones",
+                confirmation: "¿Está seguro que quiere borrar todas las regiones?",
+            },
+        },
     },
     export: {
         title: "Exportar",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -186,7 +186,7 @@ export const spanish: IAppStrings = {
         },
         assetError: "No se puede mostrar el activo",
         canvas: {
-            clearRegions: {
+            removeAllRegions: {
                 title: "Borrar Regiones",
                 confirmation: "¿Está seguro que quiere borrar todas las regiones?",
             },

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -187,7 +187,7 @@ export interface IAppStrings {
         }
         assetError: string;
         canvas: {
-            clearRegions: {
+            removeAllRegions: {
                 title: string;
                 confirmation: string;
             },

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -186,6 +186,12 @@ export interface IAppStrings {
             },
         }
         assetError: string;
+        canvas: {
+            clearRegions: {
+                title: string;
+                confirmation: string;
+            },
+        }
     };
     export: {
         title: string;

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -14,6 +14,7 @@ import { Editor } from "vott-ct/lib/js/CanvasTools/CanvasTools.Editor";
 
 jest.mock("vott-ct/lib/js/CanvasTools/Region/RegionsManager");
 import { RegionsManager } from "vott-ct/lib/js/CanvasTools/Region/RegionsManager";
+import Confirm, { IConfirmProps } from "../../common/confirm/confirm";
 
 describe("Editor Canvas", () => {
 
@@ -509,8 +510,8 @@ describe("Editor Canvas", () => {
 
     it("Clears all regions from asset", async () => {
         const wrapper = createComponent().find(Canvas);
-        const canvas = wrapper.instance() as Canvas;
-        canvas.clearRegions();
+        const clearConfirm = wrapper.find(Confirm) as ReactWrapper<IConfirmProps>;
+        clearConfirm.props().onConfirm();
 
         await MockFactory.flushUi();
         expect(wrapper.state().currentAsset.regions).toEqual([]);

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -12,6 +12,8 @@ import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Selection/AreaSelector
 import { Editor } from "vott-ct/lib/js/CanvasTools/CanvasTools.Editor";
 import { KeyboardBinding } from "../../common/keyboardBinding/keyboardBinding";
 import Clipboard from "../../../../common/clipboard";
+import Confirm from "../../common/confirm/confirm";
+import { strings } from "../../../../common/strings";
 
 export interface ICanvasProps extends React.Props<Canvas> {
     selectedAsset: IAssetMetadata;
@@ -47,6 +49,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
     private intervalTimer: number = null;
     private canvasZone: React.RefObject<HTMLDivElement> = React.createRef();
+    private clearConfirm: React.RefObject<Confirm> = React.createRef();
 
     public componentDidMount = () => {
         const sz = document.getElementById("editor-zone") as HTMLDivElement;
@@ -84,6 +87,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
     public render = () => {
         return (
             <Fragment>
+                <Confirm title="Clear Regions"
+                    ref={this.clearConfirm as any}
+                    message={strings.editorPage.canvas.clearRegions.confirmation}
+                    confirmButtonColor="danger"
+                    onConfirm={this.clearRegions}
+                />
                 <div id="ct-zone" ref={this.canvasZone} className="canvas-enabled">
                     <div id="selection-zone">
                         <div id="editor-zone" className="full-size" />
@@ -145,12 +154,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         this.addRegions(duplicates);
     }
 
-    public clearRegions = () => {
-        const ids = this.state.currentAsset.regions.map((r) => r.id);
-        for (const id of ids) {
-            this.editor.RM.deleteRegionById(id);
-        }
-        this.deleteRegionsFromAsset(this.state.currentAsset.regions);
+    public confirmClearRegions = () => {
+        this.clearConfirm.current.open();
     }
 
     public getSelectedRegions = (): IRegion[] => {
@@ -165,6 +170,14 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                 CanvasHelpers.getTagsDescriptor(this.props.project.tags, region),
             );
         }
+    }
+
+    private clearRegions = () => {
+        const ids = this.state.currentAsset.regions.map((r) => r.id);
+        for (const id of ids) {
+            this.editor.RM.deleteRegionById(id);
+        }
+        this.deleteRegionsFromAsset(this.state.currentAsset.regions);
     }
 
     private addRegions = (regions: IRegion[]) => {

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -87,11 +87,11 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
     public render = () => {
         return (
             <Fragment>
-                <Confirm title="Clear Regions"
+                <Confirm title={strings.editorPage.canvas.removeAllRegions.title}
                     ref={this.clearConfirm as any}
-                    message={strings.editorPage.canvas.clearRegions.confirmation}
+                    message={strings.editorPage.canvas.removeAllRegions.confirmation}
                     confirmButtonColor="danger"
-                    onConfirm={this.clearRegions}
+                    onConfirm={this.removeAllRegions}
                 />
                 <div id="ct-zone" ref={this.canvasZone} className="canvas-enabled">
                     <div id="selection-zone">
@@ -154,7 +154,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         this.addRegions(duplicates);
     }
 
-    public confirmClearRegions = () => {
+    public confirmRemoveAllRegions = () => {
         this.clearConfirm.current.open();
     }
 
@@ -172,7 +172,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         }
     }
 
-    private clearRegions = () => {
+    private removeAllRegions = () => {
         const ids = this.state.currentAsset.regions.map((r) => r.id);
         for (const id of ids) {
             this.editor.RM.deleteRegionById(id);

--- a/src/react/components/pages/editorPage/canvasHelpers.test.ts
+++ b/src/react/components/pages/editorPage/canvasHelpers.test.ts
@@ -105,7 +105,7 @@ describe("Canvas Helpers", () => {
 
     it("Duplicates and moves a region", () => {
         const regions = MockFactory.createTestRegions();
-        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 1000, 2000);
+        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 10000, 10000);
         expect(duplicates[0]).toMatchObject({
             ...regions[0],
             id: expect.any(String),
@@ -136,7 +136,7 @@ describe("Canvas Helpers", () => {
             boundingBox,
             points: CanvasHelpers.fromBoundingBox(boundingBox),
         };
-        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 1000, 1000);
+        const duplicates = CanvasHelpers.duplicateRegionsAndMove([regions[0]], regions, 10000, 10000);
         const expectedBoundingBox: IBoundingBox = {
             ...boundingBox,
             left: 0,
@@ -152,28 +152,28 @@ describe("Canvas Helpers", () => {
 
     it("Duplicates a region with coordinates out of range into the default location", () => {
         // Starting coordinates out of range
-        expectDefaultDuplication(1001, 1001);
+        expectDefaultDuplication(10001, 10001);
         // Starting left out of range
-        expectDefaultDuplication(1001, 0);
+        expectDefaultDuplication(10001, 0);
         // Starting right out of range
-        expectDefaultDuplication(0, 1001);
+        expectDefaultDuplication(0, 10001);
         // Both width and height put out of range
-        expectDefaultDuplication(999, 999);
+        expectDefaultDuplication(9999, 9999);
         // Width puts out of range
-        expectDefaultDuplication(999, 0);
+        expectDefaultDuplication(9999, 0);
         // Height puts out of range
-        expectDefaultDuplication(0, 999);
+        expectDefaultDuplication(0, 9999);
     });
 
     it("Throws error for region too big", () => {
         // Both width and height too big
-        expect(() => expectDefaultDuplication(500, 500, 1001, 1001)).toThrowError();
+        expect(() => expectDefaultDuplication(0, 0, 10001, 10001)).toThrowError();
         // Just width too big
-        expect(() => expectDefaultDuplication(500, 500, 1001, 10)).toThrowError();
+        expect(() => expectDefaultDuplication(0, 0, 10001, 10)).toThrowError();
         // Just height too big
-        expect(() => expectDefaultDuplication(500, 500, 10, 1001)).toThrowError();
+        expect(() => expectDefaultDuplication(0, 0, 10, 10001)).toThrowError();
         // Neither too big
-        expect(() => expectDefaultDuplication(1001, 1001, 10, 10)).not.toThrowError();
+        expect(() => expectDefaultDuplication(10001, 10001, 10, 10)).not.toThrowError();
     });
 
     it("Toggles a tag", () => {

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -28,6 +28,7 @@ import EditorFooter from "./editorFooter";
 import { AssetPreview } from "../../common/assetPreview/assetPreview";
 import Canvas from "./canvas";
 import { appInfo } from "../../../../common/appInfo";
+import Confirm, { IConfirmProps } from "../../common/confirm/confirm";
 
 function createComponent(store, props: IEditorPageProps): ReactWrapper<IEditorPageProps, {}, EditorPage> {
     return mount(
@@ -395,7 +396,7 @@ describe("Editor Page Component", () => {
         const copyRegions = jest.fn();
         const cutRegions = jest.fn();
         const pasteRegions = jest.fn();
-        const clearRegions = jest.fn();
+        const confirmClearRegions = jest.fn();
 
         beforeAll(() => {
             registerToolbar();
@@ -421,7 +422,7 @@ describe("Editor Page Component", () => {
             canvas.copyRegions = copyRegions;
             canvas.cutRegions = cutRegions;
             canvas.pasteRegions = pasteRegions;
-            canvas.clearRegions = clearRegions;
+            canvas.confirmClearRegions = confirmClearRegions;
         });
 
         it("editor mode is changed correctly", async () => {
@@ -476,10 +477,10 @@ describe("Editor Page Component", () => {
             expect(pasteRegions).toBeCalled();
         });
 
-        it("Calls clear regions with button click", async () => {
+        it("Calls clear regions with button click and confirmation", async () => {
             await MockFactory.flushUi(() => wrapper
                 .find(`.${ToolbarItemName.ClearRegions}`).simulate("click"));
-            expect(clearRegions).toBeCalled();
+            expect(confirmClearRegions).toBeCalled();
         });
 
         it("Calls copy regions with hot key", async () => {
@@ -497,11 +498,10 @@ describe("Editor Page Component", () => {
             expect(pasteRegions).toBeCalled();
         });
 
-        it("Calls clear regions with hot key", async () => {
+        it("Calls clear regions with hot key and confirmation", async () => {
             dispatchKeyEvent("Ctrl+Delete");
-            expect(clearRegions).toBeCalled();
+            expect(confirmClearRegions).toBeCalled();
         });
-
 
         it("sets selected tag and locked tags when hot key is pressed", async () => {
             const project = MockFactory.createTestProject();

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -396,7 +396,7 @@ describe("Editor Page Component", () => {
         const copyRegions = jest.fn();
         const cutRegions = jest.fn();
         const pasteRegions = jest.fn();
-        const confirmClearRegions = jest.fn();
+        const removeAllRegionsConfirm = jest.fn();
 
         beforeAll(() => {
             registerToolbar();
@@ -422,7 +422,7 @@ describe("Editor Page Component", () => {
             canvas.copyRegions = copyRegions;
             canvas.cutRegions = cutRegions;
             canvas.pasteRegions = pasteRegions;
-            canvas.confirmClearRegions = confirmClearRegions;
+            canvas.confirmRemoveAllRegions = removeAllRegionsConfirm;
         });
 
         it("editor mode is changed correctly", async () => {
@@ -477,10 +477,10 @@ describe("Editor Page Component", () => {
             expect(pasteRegions).toBeCalled();
         });
 
-        it("Calls clear regions with button click and confirmation", async () => {
+        it("Calls remove all regions confirmation with button click", async () => {
             await MockFactory.flushUi(() => wrapper
-                .find(`.${ToolbarItemName.ClearRegions}`).simulate("click"));
-            expect(confirmClearRegions).toBeCalled();
+                .find(`.${ToolbarItemName.RemoveAllRegions}`).simulate("click"));
+            expect(removeAllRegionsConfirm).toBeCalled();
         });
 
         it("Calls copy regions with hot key", async () => {
@@ -498,9 +498,9 @@ describe("Editor Page Component", () => {
             expect(pasteRegions).toBeCalled();
         });
 
-        it("Calls clear regions with hot key and confirmation", async () => {
+        it("Calls remove all regions confirmation with hot key", async () => {
             dispatchKeyEvent("Ctrl+Delete");
-            expect(confirmClearRegions).toBeCalled();
+            expect(removeAllRegionsConfirm).toBeCalled();
         });
 
         it("sets selected tag and locked tags when hot key is pressed", async () => {

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -497,6 +497,12 @@ describe("Editor Page Component", () => {
             expect(pasteRegions).toBeCalled();
         });
 
+        it("Calls clear regions with hot key", async () => {
+            dispatchKeyEvent("Ctrl+Delete");
+            expect(clearRegions).toBeCalled();
+        });
+
+
         it("sets selected tag and locked tags when hot key is pressed", async () => {
             const project = MockFactory.createTestProject();
             const store = createReduxStore({

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -346,8 +346,8 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             case ToolbarItemName.PasteRegions:
                 this.canvas.current.pasteRegions();
                 break;
-            case ToolbarItemName.ClearRegions:
-                this.canvas.current.confirmClearRegions();
+            case ToolbarItemName.RemoveAllRegions:
+                this.canvas.current.confirmRemoveAllRegions();
                 break;
         }
     }

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -347,7 +347,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 this.canvas.current.pasteRegions();
                 break;
             case ToolbarItemName.ClearRegions:
-                this.canvas.current.clearRegions();
+                this.canvas.current.confirmClearRegions();
                 break;
         }
     }

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -2,6 +2,7 @@ import { ToolbarItemFactory } from "./providers/toolbar/toolbarItemFactory";
 import { ExportProject } from "./react/components/toolbar/exportProject";
 import { SaveProject } from "./react/components/toolbar/saveProject";
 import { ToolbarItemType } from "./react/components/toolbar/toolbarItem";
+import { strings } from "./common/strings";
 
 export enum ToolbarItemName {
     SelectCanvas = "selectCanvas",
@@ -11,7 +12,7 @@ export enum ToolbarItemName {
     CopyRegions = "copyRegions",
     CutRegions = "cutRegions",
     PasteRegions = "pasteRegions",
-    ClearRegions = "clearRegions",
+    RemoveAllRegions = "removeAllRegions",
     PreviousAsset = "navigatePreviousAsset",
     NextAsset = "navigateNextAsset",
     SaveProject = "saveProject",
@@ -84,8 +85,8 @@ export default function registerToolbar() {
     });
 
     ToolbarItemFactory.register({
-        name: ToolbarItemName.ClearRegions,
-        tooltip: "Clear Regions",
+        name: ToolbarItemName.RemoveAllRegions,
+        tooltip: strings.editorPage.canvas.removeAllRegions.title,
         icon: "fa-ban",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -89,6 +89,7 @@ export default function registerToolbar() {
         icon: "fa-trash-alt",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
+        accelerators: ["Ctrl+Delete"]
     });
 
     ToolbarItemFactory.register({

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -86,10 +86,10 @@ export default function registerToolbar() {
     ToolbarItemFactory.register({
         name: ToolbarItemName.ClearRegions,
         tooltip: "Clear Regions",
-        icon: "fa-trash-alt",
+        icon: "fa-ban",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+Delete"]
+        accelerators: ["Ctrl+Delete"],
     });
 
     ToolbarItemFactory.register({


### PR DESCRIPTION
- Clear regions now has a confirmation modal before actually performing the action
- Ctrl+Delete now triggers the confirmation modal
- Icon for clearing regions is now the Ghostbuster's "ban" icon