### PR TITLE
ci: script to deploy VoTT to Azure

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "electron-start": "node src/electron/start",
         "eject": "react-scripts eject",
         "release-pr": "./scripts/release-pr.sh",
+        "release-web": "npm run build && npm run webpack:prod",
         "release": "npm run build && npm run webpack:prod && electron-builder",
         "pretest": "./node_modules/.bin/tslint 'src/**/*.ts*'",
         "lintfix": "./node_modules/.bin/tslint 'src/**/*.ts*' --fix",

--- a/public/index.html
+++ b/public/index.html
@@ -19,13 +19,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Visual Object Tagging Tool (VoTT) v%REACT_APP_VERSION%</title>
   </head>
   <body>
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
+    <div id="appInfo">VoTT v%REACT_APP_VERSION%, commit=%REACT_APP_COMMIT_SHA%</div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/scripts/deploy-to-azure.sh
+++ b/scripts/deploy-to-azure.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# NOTE: this script should be ran from the root of the repository; the CWD should reflect this
+VERSION=$(node -pe "require('./package.json').version")
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
+echo "cwd=$(pwd)"
+echo "version=${VERSION}"
+echo "commit=${COMMIT_SHA}"
+
+
+export REACT_APP_VERSION=${VERSION}
+export REACT_APP_COMMIT_SHA=${COMMIT_SHA}
+
+npm ci
+npm run release-web
+
+#NOTE: be sure to set AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY environment variables
+# push VoTT SPA to blob - CLI will correctly take care of MIME types
+az storage blob upload-batch -d '$web' -s build

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -55,6 +55,7 @@ export const english: IAppStrings = {
         version: {
             description: "Version:",
         },
+        commit: "Commit SHA",
         devTools: {
             description: "Open application developer tools to help diagnose issues",
             button: "Toggle Developer Tools",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -56,6 +56,7 @@ export const spanish: IAppStrings = {
         version: {
             description: "Versión:",
         },
+        commit: "Cometer SHA",
         devTools: {
             description: "Abrir herramientas de desarrollo de aplicaciones para ayudar a diagnosticar problemas.",
             button: "Alternar Herramientas de Desarrollo",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -57,6 +57,7 @@ export interface IAppStrings {
         version: {
             description: string;
         },
+        commit: string,
         devTools: {
             description: string;
             button: string;

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,10 @@
     overflow: hidden;
 }
 
+#appInfo {
+    display: none;
+}
+
 input[type=file] {
     display: none;
 }

--- a/src/react/components/pages/appSettings/appSettingsPage.tsx
+++ b/src/react/components/pages/appSettings/appSettingsPage.tsx
@@ -65,6 +65,9 @@ export default class AppSettingsPage extends React.Component<IAppSettingsProps> 
                         <p>{`${strings.appSettings.version.description} ${appInfo.version}`}</p>
                     </div>
                     <div className="my-3">
+                        <p>{`${strings.appSettings.commit}: `} {process.env.REACT_APP_COMMIT_SHA}</p>
+                    </div>
+                    <div className="my-3">
                         <p>{strings.appSettings.devTools.description}</p>
                         <button id="toggleDevTools" className="btn btn-primary btn-sm"
                             onClick={this.toggleDevTools}>{strings.appSettings.devTools.button}


### PR DESCRIPTION
Script to push VoTT single page app to Azure as a static Web site.
Display version/commit SHA in multiple places to be able to easily
determine version.

[AB#17484](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=17484)

Preview deployment available here: https://vottdev.z5.web.core.windows.net