### PR TITLE
fix: save asset metadata for all valid asset type [AB#17538]

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -240,7 +240,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
      * Returns a value indicating whether the current asset is taggable
      */
     private isTaggableAssetType = (asset: IAsset): boolean => {
-        return asset.type === AssetType.Image || asset.type === AssetType.VideoFrame;
+        return asset.type !== AssetType.Unknown && asset.type !== AssetType.Video;
     }
 
     /**


### PR DESCRIPTION
- save asset metadata for all valid asset type

Fix [AB#17538]