### PR TITLE
fix: Re-apply tags in editor when project tags are updated

### DIFF
--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -16,9 +16,9 @@ import { RegionsManager } from "vott-ct/lib/js/CanvasTools/Region/RegionsManager
 import Confirm, { IConfirmProps } from "../../common/confirm/confirm";
 import { Rect } from "vott-ct/lib/js/CanvasTools/Core/Rect";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Interface/ISelectorSettings";
+import { wrap } from "module";
 
 describe("Editor Canvas", () => {
-
     function createComponent(canvasProps?: ICanvasProps, assetPreviewProps?: IAssetPreviewProps)
         : ReactWrapper<ICanvasProps, ICanvasState, Canvas> {
         const props = createProps();
@@ -76,8 +76,9 @@ describe("Editor Canvas", () => {
         editorMock.prototype.scaleRegionToSourceSize = jest.fn((regionData: any) => regionData);
         editorMock.prototype.RM = new RegionsManager(null, null);
         editorMock.prototype.AS = {
-            setSelectionMode: jest.fn(({mode, template = null}) => {selectionMode = {mode, template}; }),
-            getSelectorSettings: jest.fn(() => selectionMode) };
+            setSelectionMode: jest.fn(({ mode, template = null }) => { selectionMode = { mode, template }; }),
+            getSelectorSettings: jest.fn(() => selectionMode),
+        };
 
         const clipboard = (navigator as any).clipboard;
         if (!(clipboard && clipboard.writeText)) {
@@ -92,7 +93,7 @@ describe("Editor Canvas", () => {
         editorMock.prototype.RM = {
             ...new RegionsManager(null, null),
             getSelectedRegionsBounds: jest.fn(() => ids.map((id) => {
-                return {id};
+                return { id };
             })),
         };
     }
@@ -489,7 +490,7 @@ describe("Editor Canvas", () => {
     });
 
     it("Copies currently selected regions to clipboard", () => {
-        const wrapper = createComponent().find(Canvas);
+        const wrapper = createComponent();
         const canvas = wrapper.instance() as Canvas;
         mockSelectedRegions(["test1"]);
 
@@ -512,7 +513,7 @@ describe("Editor Canvas", () => {
                 ...cProps.selectedAsset,
                 regions: [copiedRegion],
             },
-        }).find(Canvas);
+        });
 
         const canvas = wrapper.instance() as Canvas;
 
@@ -525,7 +526,7 @@ describe("Editor Canvas", () => {
             ...copiedRegion,
             id: expect.any(String),
             boundingBox: {
-              ...copiedRegion.boundingBox,
+                ...copiedRegion.boundingBox,
                 left: copiedRegion.boundingBox.left + CanvasHelpers.pasteMargin,
                 top: copiedRegion.boundingBox.top + CanvasHelpers.pasteMargin,
             },
@@ -546,7 +547,7 @@ describe("Editor Canvas", () => {
     });
 
     it("Cuts currently selected regions to clipboard", async () => {
-        const wrapper = createComponent().find(Canvas);
+        const wrapper = createComponent();
         const original: IAssetMetadata = {
             ...wrapper.prop("selectedAsset"),
         };
@@ -568,11 +569,26 @@ describe("Editor Canvas", () => {
     });
 
     it("Clears all regions from asset", async () => {
-        const wrapper = createComponent().find(Canvas);
+        const wrapper = createComponent();
         const clearConfirm = wrapper.find(Confirm) as ReactWrapper<IConfirmProps>;
         clearConfirm.props().onConfirm();
 
         await MockFactory.flushUi();
         expect(wrapper.state().currentAsset.regions).toEqual([]);
+    });
+
+    it("Tags are re-applied when the project tags are updated", () => {
+        const wrapper = createComponent();
+        const assetMetadata = wrapper.props().selectedAsset;
+        const project = { ...wrapper.props().project };
+        const tags = [...project.tags];
+        tags[0].color = "#FFCCFF";
+        project.tags = tags;
+
+        const editor = wrapper.instance().editor;
+        const updateTagsSpy = jest.spyOn(editor.RM, "updateTagsById");
+
+        wrapper.setProps({ project });
+        expect(updateTagsSpy).toBeCalledTimes(assetMetadata.regions.length);
     });
 });

--- a/src/react/components/pages/editorPage/canvas.test.tsx
+++ b/src/react/components/pages/editorPage/canvas.test.tsx
@@ -16,7 +16,6 @@ import { RegionsManager } from "vott-ct/lib/js/CanvasTools/Region/RegionsManager
 import Confirm, { IConfirmProps } from "../../common/confirm/confirm";
 import { Rect } from "vott-ct/lib/js/CanvasTools/Core/Rect";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Interface/ISelectorSettings";
-import { wrap } from "module";
 
 describe("Editor Canvas", () => {
     function createComponent(canvasProps?: ICanvasProps, assetPreviewProps?: IAssetPreviewProps)

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -3,13 +3,12 @@ import * as shortid from "shortid";
 import { CanvasTools } from "vott-ct";
 import { RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 import {
-    AssetState, EditorMode, IAssetMetadata,
-    IProject, IRegion, ITag, RegionType,
+    EditorMode, IAssetMetadata,
+    IProject, IRegion, RegionType,
 } from "../../../../models/applicationState";
 import CanvasHelpers from "./canvasHelpers";
 import { AssetPreview, ContentSource } from "../../common/assetPreview/assetPreview";
 import { Editor } from "vott-ct/lib/js/CanvasTools/CanvasTools.Editor";
-import { KeyboardBinding } from "../../common/keyboardBinding/keyboardBinding";
 import Clipboard from "../../../../common/clipboard";
 import Confirm from "../../common/confirm/confirm";
 import { strings } from "../../../../common/strings";
@@ -85,6 +84,11 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         if (this.props.selectionMode !== prevProps.selectionMode) {
             const options = (this.props.selectionMode === SelectionMode.COPYRECT) ? this.template : null;
             this.editor.AS.setSelectionMode({ mode: this.props.selectionMode, template: options });
+        }
+
+        // When the project tags change re-apply tags to regions
+        if (this.props.project.tags !== prevProps.project.tags) {
+            this.updateCanvasToolsRegions();
         }
     }
 

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -227,7 +227,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
     }
 
     /**
-     * Raised when a child asset is selected on the Asset Prview
+     * Raised when a child asset is selected on the Asset Preview
      * ex) When a video is paused/seeked to on a video
      */
     private onChildAssetSelected = async (childAsset: IAsset) => {


### PR DESCRIPTION
Resolves issue where if tag color is modified while in the editor page, the color changes are not applied till you reload or navigate away from the current asset

Resolves AB#17264