### PR TITLE
feat: Exclude desktop functionality from browser target

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "eject": "react-scripts eject",
         "release-pr": "./scripts/release-pr.sh",
         "release-web": "npm run build && npm run webpack:prod",
-        "release": "npm run build && npm run webpack:prod && electron-builder",
+        "release": "npm run build && ./scripts/version.sh && npm run webpack:prod && electron-builder",
         "pretest": "./node_modules/.bin/tslint 'src/**/*.ts*'",
         "lintfix": "./node_modules/.bin/tslint 'src/**/*.ts*' --fix",
         "test": "react-scripts test --env=jsdom --silent",

--- a/public/index.html
+++ b/public/index.html
@@ -19,14 +19,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Visual Object Tagging Tool (VoTT)</title>
+    <title>Visual Object Tagging Tool (VoTT) v%REACT_APP_VERSION%</title>
   </head>
   <body>
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
-    <div id="appInfo">VoTT v%REACT_APP_VERSION%, commit=%REACT_APP_COMMIT_SHA%</div>
+    <div style="display: none;">VoTT v%REACT_APP_VERSION%, commit=%REACT_APP_COMMIT_SHA%</div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/scripts/release-pr.sh
+++ b/scripts/release-pr.sh
@@ -49,6 +49,7 @@ then
     git tag -a ${NEW_VERSION} -m "VoTT v${NEW_VERSION}"
     # update package.json version and the changelog
     npm install json --no-save
+    # NOTE: at some point, we need to move to `npm version` and do all of this via build system
     ./node_modules/.bin/json -I -f package.json -4 -e "this.version=\"${NEW_VERSION}\""
     ./node_modules/.bin/json -I -f package-lock.json -4 -e "this.version=\"${NEW_VERSION}\""
     ${BASEDIR}/generate-changelog.sh --from ${PREVIOUS_VERSION} --to ${NEW_VERSION}

--- a/scripts/release-pr.sh
+++ b/scripts/release-pr.sh
@@ -50,6 +50,7 @@ then
     # update package.json version and the changelog
     npm install json --no-save
     ./node_modules/.bin/json -I -f package.json -4 -e "this.version=\"${NEW_VERSION}\""
+    ./node_modules/.bin/json -I -f package-lock.json -4 -e "this.version=\"${NEW_VERSION}\""
     ${BASEDIR}/generate-changelog.sh --from ${PREVIOUS_VERSION} --to ${NEW_VERSION}
     git commit -am "ci: update package version and changelog for ${NEW_VERSION} release"
     git push -u origin ${RELEASE_BRANCH}

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# NOTE: this script should be ran from the root of the repository; the CWD should reflect this
+VERSION=$(node -pe "require('./package.json').version")
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
+echo "cwd=$(pwd)"
+echo "version=${VERSION}"
+echo "commit=${COMMIT_SHA}"
+
+npm install replace-in-file --no-save
+./node_modules/.bin/replace-in-file "%REACT_APP_VERSION%" ${VERSION} build/index.html
+./node_modules/.bin/replace-in-file "%REACT_APP_COMMIT_SHA%" ${COMMIT_SHA} build/index.html

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,10 +5,6 @@
     overflow: hidden;
 }
 
-#appInfo {
-    display: none;
-}
-
 input[type=file] {
     display: none;
 }

--- a/src/react/components/pages/appSettings/appSettingsPage.tsx
+++ b/src/react/components/pages/appSettings/appSettingsPage.tsx
@@ -9,6 +9,7 @@ import { AppSettingsForm } from "./appSettingsForm";
 import { RouteComponentProps } from "react-router-dom";
 import { toast } from "react-toastify";
 import { appInfo } from "../../../../common/appInfo";
+import getHostProcess, { HostProcessType } from "../../../../common/hostProcess";
 
 /**
  * Props for App Settings Page
@@ -67,18 +68,22 @@ export default class AppSettingsPage extends React.Component<IAppSettingsProps> 
                     <div className="my-3">
                         <p>{`${strings.appSettings.commit}: `} {process.env.REACT_APP_COMMIT_SHA}</p>
                     </div>
-                    <div className="my-3">
-                        <p>{strings.appSettings.devTools.description}</p>
-                        <button id="toggleDevTools" className="btn btn-primary btn-sm"
-                            onClick={this.toggleDevTools}>{strings.appSettings.devTools.button}
-                        </button>
-                    </div>
-                    <div className="my-3">
-                        <p>{strings.appSettings.reload.description}</p>
-                        <button id="refreshApp" className="btn btn-primary btn-sm"
-                            onClick={this.reloadApp}>{strings.appSettings.reload.button}
-                        </button>
-                    </div>
+                    { getHostProcess().type === HostProcessType.Electron &&
+                    <span>
+                        <div className="my-3">
+                            <p>{strings.appSettings.devTools.description}</p>
+                            <button id="toggleDevTools" className="btn btn-primary btn-sm"
+                                onClick={this.toggleDevTools}>{strings.appSettings.devTools.button}
+                            </button>
+                        </div>
+                        <div className="my-3">
+                            <p>{strings.appSettings.reload.description}</p>
+                            <button id="refreshApp" className="btn btn-primary btn-sm"
+                                onClick={this.reloadApp}>{strings.appSettings.reload.button}
+                            </button>
+                        </div>
+                    </span>
+                    }
                 </div>
             </div>
         );

--- a/src/react/components/pages/homepage/homePage.tsx
+++ b/src/react/components/pages/homepage/homePage.tsx
@@ -22,7 +22,6 @@ import { toast } from "react-toastify";
 import MessageBox from "../../common/messageBox/messageBox";
 import getHostProcess, { HostProcessType } from "../../../../common/hostProcess";
 
-
 export interface IHomePageProps extends RouteComponentProps, React.Props<HomePage> {
     recentProjects: IProject[];
     connections: IConnection[];

--- a/src/react/components/pages/homepage/homePage.tsx
+++ b/src/react/components/pages/homepage/homePage.tsx
@@ -20,6 +20,8 @@ import ImportService from "../../../../services/importService";
 import { IAssetMetadata } from "../../../../models/applicationState";
 import { toast } from "react-toastify";
 import MessageBox from "../../common/messageBox/messageBox";
+import getHostProcess, { HostProcessType } from "../../../../common/hostProcess";
+
 
 export interface IHomePageProps extends RouteComponentProps, React.Props<HomePage> {
     recentProjects: IProject[];
@@ -71,6 +73,7 @@ export default class HomePage extends React.Component<IHomePageProps, IHomePageS
                                 <h6>{strings.homePage.newProject}</h6>
                             </a>
                         </li>
+                        { getHostProcess().type === HostProcessType.Electron &&
                         <li>
                             <a href="#" onClick={() => this.filePicker.current.upload()} className="p-5 file-upload">
                                 <i className="fas fa-folder-open fa-9x"></i>
@@ -80,6 +83,7 @@ export default class HomePage extends React.Component<IHomePageProps, IHomePageS
                                 onChange={this.onProjectFileUpload}
                                 onError={this.onProjectFileUploadError} />
                         </li>
+                        }
                         <li>
                             {/*Open Cloud Project*/}
                             <a href="#" onClick={this.handleOpenCloudProjectClick} className="p-5 cloud-open-project">


### PR DESCRIPTION
feat: exclude desktop functionality from browser target

Remove electron functionality from browser builds. Some updates to
CI scripts found in the last release.

NOTE: need to see if `version.sh` works on windows, otherwise I have one more approach in mind.