### PR TITLE
fix: metrics page throw error if project has no tags

### DIFF
--- a/src/redux/actions/projectActions.test.ts
+++ b/src/redux/actions/projectActions.test.ts
@@ -100,6 +100,20 @@ describe("Project Redux Actions", () => {
         });
     });
 
+    it("Save Project action on new project correctly set tags to empty if none created", async () => {
+        projectServiceMock.prototype.save = jest.fn((project) => Promise.resolve(project));
+
+        const skeletonProject = MockFactory.createTestProject("TestProject");
+        const project = {
+            ...skeletonProject,
+            tags: null,
+        };
+
+        const result = await projectActions.saveProject(project)(store.dispatch, store.getState);
+
+        expect(result.tags).toEqual([]);
+    });
+
     it("Save Project action does not override existing export format", async () => {
         projectServiceMock.prototype.save = jest.fn((project) => Promise.resolve(project));
 

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -88,6 +88,7 @@ export function saveProject(project: IProject)
             ...project,
             version: appInfo.version,
             exportFormat: project.exportFormat || defaultExportFormat,
+            tags: project.tags || [],
         };
 
         const savedProject = await projectService.save(newProject, projectToken);


### PR DESCRIPTION
create empty tags array on project creation if no tags created,
right now it's null

AB#17588