### PR TITLE
fix: Remove height from root style [AB#17672]

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -5,7 +5,6 @@ body {
 }
 
 #root {
-    height: 100vh;
     overflow: hidden;
 }
 


### PR DESCRIPTION
Fixes style that hides Submit button in forms using react-jsonschema-form
# Before:
![export settings](https://user-images.githubusercontent.com/10962815/54692763-c33b0480-4ae2-11e9-8d8f-2966fbf85802.PNG)
![project space](https://user-images.githubusercontent.com/10962815/54692772-c7672200-4ae2-11e9-92f9-ca9e2279b484.PNG)
![space](https://user-images.githubusercontent.com/10962815/54692783-ca621280-4ae2-11e9-9291-77798724972a.PNG)
 # After
![export space](https://user-images.githubusercontent.com/10962815/54692798-d221b700-4ae2-11e9-9472-fdb6e769b6cd.PNG)
![project fix](https://user-images.githubusercontent.com/10962815/54692809-d4841100-4ae2-11e9-88a0-853703d5f11a.PNG)
