### PR TITLE
ci: refactor web deploy pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
+
+[*.yml]
+indent_size = 2

--- a/azure-pipelines/web/generate-web-artifact.yml
+++ b/azure-pipelines/web/generate-web-artifact.yml
@@ -1,0 +1,35 @@
+trigger:
+  branches:
+    include:
+      - dev*
+      - v2
+pr: none # disable CI build for PR
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 10.x'
+    inputs:
+      versionSpec: 10.x
+
+  - task: Npm@1
+    displayName: 'npm ci'
+    inputs:
+      command: custom
+      workingDir: .
+      verbose: false
+      customCommand: ci
+
+  - task: Bash@3
+    displayName: 'Create artifact'
+    inputs:
+      targetType: filePath
+      filePath: './scripts/generate-web-artifact.sh'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: build'
+    inputs:
+      PathtoPublish: ./build
+      ArtifactName: build

--- a/scripts/generate-web-artifact.sh
+++ b/scripts/generate-web-artifact.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# NOTE: this script should be ran from the root of the repository; the CWD should reflect this
+VERSION=$(node -pe "require('./package.json').version")
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
+echo "cwd=$(pwd)"
+echo "version=${VERSION}"
+echo "commit=${COMMIT_SHA}"
+
+# use by web pack
+export REACT_APP_VERSION=${VERSION}
+export REACT_APP_COMMIT_SHA=${COMMIT_SHA}
+
+# npm install will be in a standalone task
+npm run release-web


### PR DESCRIPTION
1. move deploy functionality to release
1. replace `az storage` command with `az copy` ADO task

Examples:
[Build](https://dev.azure.com/msft-vott/VoTT/_build/results?buildId=1930&view=logs)
[Release](https://dev.azure.com/msft-vott/VoTT/_releaseProgress?_a=release-environment-logs&releaseId=161&environmentId=161)

[AB#17779](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=17779)