### PR TITLE
style: fix typo at import project message

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -32,7 +32,7 @@ export const english: IAppStrings = {
         importProject: {
             title: "Import Project",
             confirmation: "Are you sure you want to convert project ${project.file.name} project settings" +
-                "to v2 format? We recommend you backup the project file first.",
+                " to v2 format? We recommend you backup the project file first.",
         },
     },
     appSettings: {


### PR DESCRIPTION
Fixed "settingsto" to "settings to".

<img width="514" alt="screenshot 2019-03-23 7 28 29" src="https://user-images.githubusercontent.com/1457682/54856544-5de34f80-4d3e-11e9-8861-b5068debe1f0.png">
