### PR TITLE
feat: Adds option to specify if images are included with JSON export

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -277,6 +277,12 @@ export const english: IAppStrings = {
             },
             vottJson: {
                 displayName: "VoTT JSON",
+                properties: {
+                    includeImages: {
+                        title: "Include Images",
+                        description: "Whether or not to include binary image assets in target connection",
+                    },
+                },
             },
             azureCV: {
                 displayName: "Azure Custom Vision Service",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -280,8 +280,8 @@ export const spanish: IAppStrings = {
                 displayName: "VoTT JSON",
                 properties: {
                     includeImages: {
-                        title: "Include Images",
-                        description: "Whether or not to include binary image assets in target connection",
+                        title: "Incluir imágenes",
+                        description: "Si desea o no incluir activos de imagen binaria en la conexión de destino",
                     },
                 },
             },

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -278,6 +278,12 @@ export const spanish: IAppStrings = {
             },
             vottJson: {
                 displayName: "VoTT JSON",
+                properties: {
+                    includeImages: {
+                        title: "Include Images",
+                        description: "Whether or not to include binary image assets in target connection",
+                    },
+                },
             },
             azureCV: {
                 displayName: "Servicio de Visión Personalizada Azure",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -279,6 +279,12 @@ export interface IAppStrings {
             },
             vottJson: {
                 displayName: string,
+                properties: {
+                    includeImages: {
+                        title: string,
+                        description: string,
+                    },
+                },
             },
             azureCV: {
                 displayName: string,

--- a/src/providers/export/vottJson.json
+++ b/src/providers/export/vottJson.json
@@ -17,6 +17,12 @@
                 "${strings.export.providers.common.properties.assetState.options.visited}",
                 "${strings.export.providers.common.properties.assetState.options.tagged}"
             ]
+        },
+        "includeImages": {
+            "type": "boolean",
+            "default": true,
+            "title": "${strings.export.providers.vottJson.properties.includeImages.title}",
+            "description": "${strings.export.providers.vottJson.properties.includeImages.description}"
         }
     }
 }

--- a/src/providers/export/vottJson.test.ts
+++ b/src/providers/export/vottJson.test.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { VottJsonExportProvider } from "./vottJson";
+import { VottJsonExportProvider, IVottJsonExportProviderOptions } from "./vottJson";
 import registerProviders from "../../registerProviders";
 import { ExportAssetState } from "./exportProvider";
 import { ExportProviderFactory } from "./exportProviderFactory";
@@ -60,8 +60,9 @@ describe("VoTT Json Export Provider", () => {
     });
 
     it("Can be instantiated through the factory", () => {
-        const options: IExportProviderOptions = {
+        const options: IVottJsonExportProviderOptions = {
             assetState: ExportAssetState.All,
+            includeImages: true,
         };
         const exportProvider = ExportProviderFactory.create("vottJson", testProject, options);
         expect(exportProvider).not.toBeNull();
@@ -82,12 +83,15 @@ describe("VoTT Json Export Provider", () => {
             });
 
             const storageProviderMock = LocalFileSystemProxy as jest.Mock<LocalFileSystemProxy>;
+            storageProviderMock.prototype.writeText.mockClear();
+            storageProviderMock.prototype.writeBinary.mockClear();
             storageProviderMock.mockClear();
         });
 
         it("Exports all assets", async () => {
-            const options: IExportProviderOptions = {
+            const options: IVottJsonExportProviderOptions = {
                 assetState: ExportAssetState.All,
+                includeImages: true,
             };
 
             const exportProvider = new VottJsonExportProvider(testProject, options);
@@ -95,18 +99,25 @@ describe("VoTT Json Export Provider", () => {
 
             const storageProviderMock = LocalFileSystemProxy as any;
             const exportJson = storageProviderMock.mock.instances[0].writeText.mock.calls[0][1];
-            const exportObject = JSON.parse(exportJson);
+            const exportObject = JSON.parse(exportJson) as IProject;
 
             const exportedAssets = _.values(exportObject.assets);
 
+            // Ensure provider information not included in export JSON
+            expect(exportObject.sourceConnection).toBeUndefined();
+            expect(exportObject.targetConnection).toBeUndefined();
+            expect(exportObject.exportFormat).toBeUndefined();
+
+            // Verify exported assets match expectations
             expect(exportedAssets.length).toEqual(testAssets.length);
             expect(LocalFileSystemProxy.prototype.writeText)
                 .toBeCalledWith(expectedFileName, expect.any(String));
         });
 
         it("Exports only visited assets (includes tagged)", async () => {
-            const options: IExportProviderOptions = {
+            const options: IVottJsonExportProviderOptions = {
                 assetState: ExportAssetState.Visited,
+                includeImages: true,
             };
 
             const exportProvider = new VottJsonExportProvider(testProject, options);
@@ -120,14 +131,21 @@ describe("VoTT Json Export Provider", () => {
             const expectedAssets = _.values(testProject.assets)
                 .filter((asset) => asset.state === AssetState.Visited || asset.state === AssetState.Tagged);
 
+            // Ensure provider information not included in export JSON
+            expect(exportObject.sourceConnection).toBeUndefined();
+            expect(exportObject.targetConnection).toBeUndefined();
+            expect(exportObject.exportFormat).toBeUndefined();
+
+            // Verify exported assets match expectations
             expect(exportedAssets.length).toEqual(expectedAssets.length);
             expect(LocalFileSystemProxy.prototype.writeText)
                 .toBeCalledWith(expectedFileName, expect.any(String));
         });
 
         it("Exports only tagged assets", async () => {
-            const options: IExportProviderOptions = {
+            const options: IVottJsonExportProviderOptions = {
                 assetState: ExportAssetState.Tagged,
+                includeImages: true,
             };
 
             const exportProvider = new VottJsonExportProvider(testProject, options);
@@ -140,9 +158,41 @@ describe("VoTT Json Export Provider", () => {
             const exportedAssets = _.values(exportObject.assets);
             const expectedAssets = _.values(testProject.assets).filter((asset) => asset.state === AssetState.Tagged);
 
+            // Ensure provider information not included in export JSON
+            expect(exportObject.sourceConnection).toBeUndefined();
+            expect(exportObject.targetConnection).toBeUndefined();
+            expect(exportObject.exportFormat).toBeUndefined();
+
+            // Verify exported assets match expectations
             expect(exportedAssets.length).toEqual(expectedAssets.length);
             expect(LocalFileSystemProxy.prototype.writeText)
                 .toBeCalledWith(expectedFileName, expect.any(String));
+        });
+
+        it("Includes images in export when option is selected", async () => {
+            const options: IVottJsonExportProviderOptions = {
+                assetState: ExportAssetState.All,
+                includeImages: true,
+            };
+
+            const exportProvider = new VottJsonExportProvider(testProject, options);
+            await exportProvider.export();
+
+            expect(LocalFileSystemProxy.prototype.writeText).toBeCalledTimes(1);
+            expect(LocalFileSystemProxy.prototype.writeBinary).toBeCalledTimes(testAssets.length);
+        });
+
+        it("Does not include images in export when option is not selected", async () => {
+            const options: IVottJsonExportProviderOptions = {
+                assetState: ExportAssetState.All,
+                includeImages: false,
+            };
+
+            const exportProvider = new VottJsonExportProvider(testProject, options);
+            await exportProvider.export();
+
+            expect(LocalFileSystemProxy.prototype.writeText).toBeCalledTimes(1);
+            expect(LocalFileSystemProxy.prototype.writeBinary).toBeCalledTimes(0);
         });
     });
 });

--- a/src/providers/export/vottJson.ts
+++ b/src/providers/export/vottJson.ts
@@ -1,16 +1,24 @@
 import _ from "lodash";
 import { ExportProvider } from "./exportProvider";
-import { IProject, IExportProviderOptions } from "../../models/applicationState";
+import { IProject, IExportProviderOptions, IAssetMetadata } from "../../models/applicationState";
 import Guard from "../../common/guard";
 import { constants } from "../../common/constants";
 import HtmlFileReader from "../../common/htmlFileReader";
 
 /**
+ * VoTT Json Export Provider options
+ */
+export interface IVottJsonExportProviderOptions extends IExportProviderOptions {
+    /** Whether or not to include binary assets in target connection */
+    includeImages: boolean;
+}
+
+/**
  * @name - Vott Json Export Provider
  * @description - Exports a project into a single JSON file that include all configured assets
  */
-export class VottJsonExportProvider extends ExportProvider {
-    constructor(project: IProject, options: IExportProviderOptions) {
+export class VottJsonExportProvider extends ExportProvider<IVottJsonExportProviderOptions> {
+    constructor(project: IProject, options: IVottJsonExportProviderOptions) {
         super(project, options);
         Guard.null(options);
     }
@@ -21,22 +29,29 @@ export class VottJsonExportProvider extends ExportProvider {
     public async export(): Promise<void> {
         const results = await this.getAssetsForExport();
 
-        await results.forEachAsync(async (assetMetadata) => {
-            return new Promise<void>(async (resolve) => {
-                const blob = await HtmlFileReader.getAssetBlob(assetMetadata.asset);
-                const assetFilePath = `vott-json-export/${assetMetadata.asset.name}`;
-                const fileReader = new FileReader();
-                fileReader.onload = async () => {
-                    const buffer = Buffer.from(fileReader.result as ArrayBuffer);
-                    await this.storageProvider.writeBinary(assetFilePath, buffer);
-                    resolve();
-                };
-                fileReader.readAsArrayBuffer(blob);
+        if (this.options.includeImages) {
+            await results.forEachAsync(async (assetMetadata) => {
+                return new Promise<void>(async (resolve) => {
+                    const blob = await HtmlFileReader.getAssetBlob(assetMetadata.asset);
+                    const assetFilePath = `vott-json-export/${assetMetadata.asset.name}`;
+                    const fileReader = new FileReader();
+                    fileReader.onload = async () => {
+                        const buffer = Buffer.from(fileReader.result as ArrayBuffer);
+                        await this.storageProvider.writeBinary(assetFilePath, buffer);
+                        resolve();
+                    };
+                    fileReader.readAsArrayBuffer(blob);
+                });
             });
-        });
+        }
 
-        const exportObject: any = { ...this.project };
-        exportObject.assets = _.keyBy(results, (assetMetadata) => assetMetadata.asset.id);
+        const exportObject = { ...this.project };
+        exportObject.assets = _.keyBy(results, (assetMetadata) => assetMetadata.asset.id) as any;
+
+        // We don't need these fields in the export JSON
+        delete exportObject.sourceConnection;
+        delete exportObject.targetConnection;
+        delete exportObject.exportFormat;
 
         const fileName = `vott-json-export/${this.project.name.replace(" ", "-")}${constants.exportFileExtension}`;
         await this.storageProvider.writeText(fileName, JSON.stringify(exportObject, null, 4));

--- a/src/providers/export/vottJson.ui.json
+++ b/src/providers/export/vottJson.ui.json
@@ -1,1 +1,5 @@
-{}
+{
+    "includeImages": {
+        "ui:widget": "checkbox"
+    }
+}

--- a/src/react/components/pages/export/exportForm.test.tsx
+++ b/src/react/components/pages/export/exportForm.test.tsx
@@ -7,6 +7,7 @@ import MockFactory from "../../../../common/mockFactory";
 
 jest.mock("../../../../providers/export/exportProviderFactory");
 import { ExportProviderFactory } from "../../../../providers/export/exportProviderFactory";
+import { IVottJsonExportProviderOptions } from "../../../../providers/export/vottJson";
 
 describe("Export Form Component", () => {
     const exportProviderRegistrations = MockFactory.createExportProviderRegistrations();
@@ -85,11 +86,14 @@ describe("Export Form Component", () => {
     });
 
     it("Calls submit handler when form is submitted", (done) => {
+        const jsonExportProviderOptions: IVottJsonExportProviderOptions = {
+            assetState: ExportAssetState.Visited,
+            includeImages: true,
+        };
+
         const defaultExportSettings: IExportFormat = {
             providerType: "vottJson",
-            providerOptions: {
-                assetState: ExportAssetState.Visited,
-            },
+            providerOptions: jsonExportProviderOptions,
         };
 
         const props: IExportFormProps = {


### PR DESCRIPTION
Adds option that allows the user to specify whether or not binary images assets will be generated as part of the JSON export provider

Resolves [AB#18068](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=18068)
