### PR TITLE
feat: Enforce asset tagging before switching assets

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -260,7 +260,7 @@ export const english: IAppStrings = {
             enforceTaggedRegions: {
                 title: "Invalid region(s) detected",
                 // tslint:disable-next-line:max-line-length
-                description: "1 or more regions have not been tagged.  Please tag all regions before continuing to next asset.",
+                description: "1 or more regions have not been tagged.  Ensuare all regions are tagged before continuing to next asset.",
             },
         },
     },

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -256,6 +256,13 @@ export const english: IAppStrings = {
                 confirmation: "Are you sure you want to remove all regions?",
             },
         },
+        messages: {
+            enforceTaggedRegions: {
+                title: "Invalid region(s) detected",
+                // tslint:disable-next-line:max-line-length
+                description: "1 or more regions have not been tagged.  Please tag all regions before continuing to next asset.",
+            },
+        },
     },
     export: {
         title: "Export",

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -260,7 +260,7 @@ export const english: IAppStrings = {
             enforceTaggedRegions: {
                 title: "Invalid region(s) detected",
                 // tslint:disable-next-line:max-line-length
-                description: "1 or more regions have not been tagged.  Ensuare all regions are tagged before continuing to next asset.",
+                description: "1 or more regions have not been tagged.  Ensure all regions are tagged before continuing to next asset.",
             },
         },
     },

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -257,6 +257,13 @@ export const spanish: IAppStrings = {
                 confirmation: "¿Está seguro que quiere borrar todas las regiones?",
             },
         },
+        messages: {
+            enforceTaggedRegions: {
+                title: "Las regiones no válidas detectadas",
+                // tslint:disable-next-line:max-line-length
+                description: "1 o más regiones no se han etiquetado.  Por favor, etiquete todas las regiones antes de continuar con el siguiente activo.",
+            },
+        },
     },
     export: {
         title: "Exportar",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -257,6 +257,12 @@ export interface IAppStrings {
                 title: string;
                 confirmation: string;
             },
+        },
+        messages: {
+            enforceTaggedRegions: {
+                title: string,
+                description: string,
+            },
         }
     };
     export: {

--- a/src/react/components/common/assetPreview/assetPreview.test.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.test.tsx
@@ -30,15 +30,25 @@ describe("Asset Preview Component", () => {
         onError: onErrorHandler,
         onActivated: onActivatedHandler,
         onDeactivated: onDeactivatedHandler,
+        onBeforeAssetChanged: onBeforeAssetChangedHandler,
         onAssetChanged: onAssetChangedHandler,
         onChildAssetSelected: onChildAssetSelectedHandler,
-        onBeforeAssetChanged: onBeforeAssetChangedHandler,
     };
 
     function createComponent(props?: IAssetPreviewProps): ReactWrapper<IAssetPreviewProps, IAssetPreviewState> {
         props = props || defaultProps;
         return mount(<AssetPreview {...props} />);
     }
+
+    beforeEach(() => {
+        onLoadedHandler.mockClear();
+        onErrorHandler.mockClear();
+        onActivatedHandler.mockClear();
+        onDeactivatedHandler.mockClear();
+        onBeforeAssetChangedHandler.mockClear();
+        onAssetChangedHandler.mockClear();
+        onChildAssetSelectedHandler.mockClear();
+    });
 
     it("renders an image asset when asset type is image", () => {
         wrapper = createComponent();
@@ -183,7 +193,6 @@ describe("Asset Preview Component", () => {
 
     it("raises onBeforeAssetChanged during asset transitions", () => {
         const videoAsset = MockFactory.createVideoTestAsset("test-video-asset");
-        const childAsset = MockFactory.createChildVideoAsset(videoAsset, 2);
         const props: IAssetPreviewProps = {
             ...defaultProps,
             asset: videoAsset,
@@ -192,6 +201,23 @@ describe("Asset Preview Component", () => {
         wrapper.find(VideoAsset).props().onBeforeAssetChanged();
 
         expect(onBeforeAssetChangedHandler).toBeCalled();
+    });
+
+    it("blocks onChildAssetSelected", () => {
+        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset");
+        const childAsset = MockFactory.createChildVideoAsset(videoAsset, 2);
+        onBeforeAssetChangedHandler.mockImplementationOnce(() => false);
+
+        const props: IAssetPreviewProps = {
+            ...defaultProps,
+            asset: videoAsset,
+        };
+        wrapper = createComponent(props);
+        wrapper.find(VideoAsset).props().onChildAssetSelected(childAsset);
+
+        expect(onBeforeAssetChangedHandler).toBeCalled();
+        expect(onChildAssetSelectedHandler).not.toBeCalled();
+        expect(onAssetChangedHandler).not.toBeCalled();
     });
 
     it("renders landscape asset correctly", () => {

--- a/src/react/components/common/assetPreview/assetPreview.test.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.test.tsx
@@ -16,6 +16,8 @@ describe("Asset Preview Component", () => {
     const onActivatedHandler = jest.fn();
     const onDeactivatedHandler = jest.fn();
     const onChildAssetSelectedHandler = jest.fn();
+    const onAssetChangedHandler = jest.fn();
+    const onBeforeAssetChangedHandler = jest.fn(() => true);
 
     const defaultProps: IAssetPreviewProps = {
         asset: {
@@ -23,11 +25,14 @@ describe("Asset Preview Component", () => {
             path: dataUri,
         },
         autoPlay: false,
+        controlsEnabled: true,
         onLoaded: onLoadedHandler,
         onError: onErrorHandler,
         onActivated: onActivatedHandler,
         onDeactivated: onDeactivatedHandler,
+        onAssetChanged: onAssetChangedHandler,
         onChildAssetSelected: onChildAssetSelectedHandler,
+        onBeforeAssetChanged: onBeforeAssetChangedHandler,
     };
 
     function createComponent(props?: IAssetPreviewProps): ReactWrapper<IAssetPreviewProps, IAssetPreviewState> {
@@ -37,7 +42,12 @@ describe("Asset Preview Component", () => {
 
     it("renders an image asset when asset type is image", () => {
         wrapper = createComponent();
+        const imageProps = wrapper.find(ImageAsset).props();
+
         expect(wrapper.find(ImageAsset).exists()).toBe(true);
+        expect(imageProps.onActivated).toBe(onActivatedHandler);
+        expect(imageProps.onDeactivated).toBe(onDeactivatedHandler);
+
     });
 
     it("renders a video asset when asset type is video", () => {
@@ -46,20 +56,26 @@ describe("Asset Preview Component", () => {
             asset: MockFactory.createVideoTestAsset("test-video-asset"),
         };
         wrapper = createComponent(props);
+        const videoProps = wrapper.find(VideoAsset).props();
+
         expect(wrapper.find(VideoAsset).exists()).toBe(true);
+        expect(videoProps.controlsEnabled).toBe(defaultProps.controlsEnabled);
+        expect(videoProps.onActivated).toBe(onActivatedHandler);
+        expect(videoProps.onDeactivated).toBe(onDeactivatedHandler);
+        expect(videoProps.onBeforeAssetChanged).toBe(onBeforeAssetChangedHandler);
     });
 
     it("renders a tfrecord asset when asset type is tfrecord", () => {
         const props: IAssetPreviewProps = {
             ...defaultProps,
             asset: MockFactory.createTestAsset("test-record-asset",
-                                                AssetState.Visited,
-                                                dataUri,
-                                                AssetType.TFRecord),
+                AssetState.Visited,
+                dataUri,
+                AssetType.TFRecord),
         };
         wrapper = createComponent(props);
         expect(wrapper.find(TFRecordAsset).exists()).toBe(true);
-        expect(wrapper.instance().state).toMatchObject({hasError: false});
+        expect(wrapper.instance().state).toMatchObject({ hasError: false });
     });
 
     it("renders loading indicator if asset isn't fully loaded", () => {
@@ -163,6 +179,19 @@ describe("Asset Preview Component", () => {
         wrapper.find(VideoAsset).props().onChildAssetSelected(childAsset);
 
         expect(onChildAssetSelectedHandler).toBeCalledWith(childAsset);
+    });
+
+    it("raises onBeforeAssetChanged during asset transitions", () => {
+        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset");
+        const childAsset = MockFactory.createChildVideoAsset(videoAsset, 2);
+        const props: IAssetPreviewProps = {
+            ...defaultProps,
+            asset: videoAsset,
+        };
+        wrapper = createComponent(props);
+        wrapper.find(VideoAsset).props().onBeforeAssetChanged();
+
+        expect(onBeforeAssetChangedHandler).toBeCalled();
     });
 
     it("renders landscape asset correctly", () => {

--- a/src/react/components/common/assetPreview/assetPreview.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.tsx
@@ -17,6 +17,8 @@ export interface IAssetProps {
     childAssets?: IAsset[];
     /** Additional settings for this asset */
     additionalSettings?: IAssetPreviewSettings;
+    /** Specifies whether the asset controls are enabled */
+    controlsEnabled?: boolean;
     /** Event handler that fires when the asset has been loaded */
     onLoaded?: (ContentSource: ContentSource) => void;
     /** Event handler that fires when the asset has been activated (ex. Video resumes playing) */
@@ -29,6 +31,8 @@ export interface IAssetProps {
     onError?: (event: React.SyntheticEvent) => void;
     /** Event handler that fires when the loaded asset has changed */
     onAssetChanged?: (asset: IAsset) => void;
+    /** Event handler that fires right before an asset has changed */
+    onBeforeAssetChanged?: () => boolean;
 }
 
 /**
@@ -66,6 +70,7 @@ export class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPrev
         asset: null,
         childAssets: [],
         autoPlay: false,
+        controlsEnabled: true,
     };
 
     /** The internal state for the component */
@@ -138,12 +143,14 @@ export class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPrev
             case AssetType.Video:
             case AssetType.VideoFrame:
                 return <VideoAsset asset={rootAsset}
+                    controlsEnabled={this.props.controlsEnabled}
                     additionalSettings={this.props.additionalSettings}
                     childAssets={childAssets}
                     timestamp={asset.timestamp}
                     autoPlay={autoPlay}
                     onLoaded={this.onAssetLoad}
                     onError={this.onError}
+                    onBeforeAssetChanged={this.props.onBeforeAssetChanged}
                     onChildAssetSelected={this.onChildAssetSelected}
                     onActivated={this.props.onActivated}
                     onDeactivated={this.props.onDeactivated} />;
@@ -184,6 +191,12 @@ export class AssetPreview extends React.Component<IAssetPreviewProps, IAssetPrev
     }
 
     private onChildAssetSelected = (asset: IAsset) => {
+        if (this.props.onBeforeAssetChanged) {
+            if (!this.props.onBeforeAssetChanged()) {
+                return;
+            }
+        }
+
         if (this.props.onChildAssetSelected) {
             this.props.onChildAssetSelected(asset);
         }

--- a/src/react/components/common/assetPreview/videoAsset.test.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.test.tsx
@@ -168,7 +168,7 @@ describe("Video Asset Component", () => {
             expect(onChildSelectedHandler).toBeCalledWith(expectedAsset);
         });
 
-        it("blocks moving to next tagged from when navigation is cancelled", () => {
+        it("blocks moving to next tagged frame when navigation is cancelled", () => {
             const currentAsset = childAssets[0];
 
             onBeforeAssetChangedHandler.mockImplementationOnce(() => false);

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -46,6 +46,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     /** Default properties for the VideoAsset if not defined */
     public static defaultProps: IVideoAssetProps = {
         autoPlay: true,
+        controlsEnabled: true,
         timestamp: null,
         asset: null,
         childAssets: [],

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from "react";
+import React, { SyntheticEvent, Fragment } from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
 import {
@@ -76,6 +76,11 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
                 <BigPlayButton position="center" />
                 {autoPlay &&
                     <ControlBar autoHide={false}>
+                        {!this.props.controlsEnabled &&
+                            <Fragment>
+                                <div className="video-react-control-bar-disabled"></div>
+                            </Fragment>
+                        }
                         <CustomVideoPlayerButton order={1.1}
                             accelerators={["ArrowLeft", "A", "a"]}
                             tooltip={strings.editorPage.videoPlayer.previousExpectedFrame.tooltip}
@@ -202,6 +207,13 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
         const playerState = this.getVideoPlayerState();
 
         if (seekTime >= 0 && playerState.currentTime !== seekTime) {
+            // Verifies if the seek operation should continue
+            if (this.props.onBeforeAssetChanged) {
+                if (!this.props.onBeforeAssetChanged()) {
+                    return;
+                }
+            }
+
             // Before seeking, pause the video
             if (!playerState.paused) {
                 this.videoPlayer.current.pause();

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -65,7 +65,15 @@
       }
 
       &-control-bar {
-        position: static;
+        position: relative;
+
+        &-disabled {
+          background-color: $darker-6;
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          z-index: 2;
+        }
       }
     }
   }

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -185,6 +185,7 @@
   top: 0;
   width: 100%;
   height: 100%;
+  z-index: 1;
 
   .video-timeline {
     &-tagged,

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -155,7 +155,7 @@ describe("Editor Page Component", () => {
         expect(editorPage.state().selectedAsset).toMatchObject({
             asset: {
                 ...expectedAsset,
-                state: AssetState.Tagged,
+                state: AssetState.Visited,
             },
         });
     });
@@ -191,7 +191,7 @@ describe("Editor Page Component", () => {
             expect.objectContaining({
                 asset: {
                     ...expectedAsset,
-                    state: AssetState.Tagged,
+                    state: AssetState.Visited,
                 },
             }),
         );
@@ -231,7 +231,7 @@ describe("Editor Page Component", () => {
             expect.objectContaining({
                 asset: {
                     ...expectedAsset,
-                    state: AssetState.Tagged,
+                    state: AssetState.Visited,
                 },
             }),
         );
@@ -289,7 +289,7 @@ describe("Editor Page Component", () => {
 
         const editedImageAsset: IAssetMetadata = {
             asset: imageAsset,
-            regions: [MockFactory.createTestRegion()],
+            regions: [MockFactory.createTestRegion("editedImageAsset", ["test"])],
             version: appInfo.version,
         };
 
@@ -353,11 +353,9 @@ describe("Editor Page Component", () => {
                 regions: [],
             }));
 
-            const newRegion = MockFactory.createTestRegion("region1", ["test"]);
-
             const editedVideoFrame: IAssetMetadata = {
                 asset: videoFrames[0],
-                regions: [newRegion],
+                regions: [MockFactory.createTestRegion("region1", ["test"])],
                 version: appInfo.version,
             };
 
@@ -374,7 +372,7 @@ describe("Editor Page Component", () => {
                     ...videoAsset,
                     state: AssetState.Tagged,
                 },
-                regions: [newRegion],
+                regions: [],
                 version: appInfo.version,
             };
 

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -78,7 +78,7 @@ describe("Editor Page Component", () => {
         assetServiceMock.prototype.getAssetMetadata = jest.fn((asset) => {
             const assetMetadata: IAssetMetadata = {
                 asset: { ...asset },
-                regions: [MockFactory.createTestRegion()],
+                regions: [],
                 version: appInfo.version,
             };
 
@@ -353,9 +353,11 @@ describe("Editor Page Component", () => {
                 regions: [],
             }));
 
+            const newRegion = MockFactory.createTestRegion("region1", ["test"]);
+
             const editedVideoFrame: IAssetMetadata = {
                 asset: videoFrames[0],
-                regions: [MockFactory.createTestRegion()],
+                regions: [newRegion],
                 version: appInfo.version,
             };
 
@@ -372,7 +374,7 @@ describe("Editor Page Component", () => {
                     ...videoAsset,
                     state: AssetState.Tagged,
                 },
-                regions: [],
+                regions: [newRegion],
                 version: appInfo.version,
             };
 

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -1,7 +1,5 @@
 import _ from "lodash";
-import Align from "rc-align";
 import React, { RefObject } from "react";
-import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 import SplitPane from "react-split-pane";

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -72,7 +72,10 @@ export interface IEditorPageState {
     lockedTags: string[];
     /** Size of the asset thumbnails to display in the side bar */
     thumbnailSize: ISize;
-    /** Whether or not the editor is in a valid state */
+    /**
+     * Whether or not the editor is in a valid state
+     * State is invalid when a region has not been tagged
+     */
     isValid: boolean;
     /** Whether the show invalid region warning alert should display */
     showInvalidRegionWarning: boolean;

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -234,9 +234,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     </div>
                 </SplitPane>
                 <Alert show={this.state.showInvalidRegionWarning}
-                    title="Invalid region(s) detected"
+                    title={strings.editorPage.messages.enforceTaggedRegions.title}
                     // tslint:disable-next-line:max-line-length
-                    message="1 or more regions have not been tagged.  Please tag all regions before continuing to next asset."
+                    message={strings.editorPage.messages.enforceTaggedRegions.description}
                     closeButtonColor="info"
                     onClose={() => this.setState({ showInvalidRegionWarning: false })} />
             </div>

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -14,6 +14,7 @@ import { strings } from "../../../../common/strings";
 export interface IEditorSideBarProps {
     assets: IAsset[];
     onAssetSelected: (asset: IAsset) => void;
+    onBeforeAssetSelected?: () => boolean;
     selectedAsset?: IAsset;
     thumbnailSize?: ISize;
 }
@@ -91,6 +92,12 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     }
 
     private onAssetClicked = (asset: IAsset): void => {
+        if (this.props.onBeforeAssetSelected) {
+            if (!this.props.onBeforeAssetSelected()) {
+                return;
+            }
+        }
+
         this.selectAsset(asset);
         this.props.onAssetSelected(asset);
     }


### PR DESCRIPTION
Enforces that there are no untagged regions within an asset before navigating away from the current loaded asset.  Displays an alert warning when user attempt to navigate.

![image](https://user-images.githubusercontent.com/6540159/55764272-bd6c7b00-5a1f-11e9-9b79-68be8ece4740.png)

Resolved [AB#18070](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=18070)