### PR TITLE
fix: CORS warning message for Bing Image Search

### DIFF
--- a/src/common/hostProcess.ts
+++ b/src/common/hostProcess.ts
@@ -47,4 +47,8 @@ export function isElectron(): boolean {
     return getHostProcess().type === HostProcessType.Electron;
 }
 
+export function isBrowser(): boolean {
+    return getHostProcess().type === HostProcessType.Browser;
+}
+
 export default getHostProcess;

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -163,6 +163,12 @@ export const english: IAppStrings = {
             saveSuccess: "Successfully saved ${connection.name}",
             deleteSuccess: "Successfully deleted ${connection.name}",
         },
+        imageCorsWarning: "Warning: When using VoTT in a Web browser, some assets from Bing Image \
+                          Search may not export correctly due to CORS (Cross Origin Resource Sharing) restrictions.",
+        blobCorsWarning: "Warning: CORS (Cross Domain Resource Sharing) must be enabled on the Azure Blob Storage \
+                          account, in order to use it as a source or target connection. More information on \
+                          enabling CORS can be found in the {0}",
+        azDocLinkText: "Azure Documentation.",
         providers: {
             azureBlob: {
                 title: "Azure Blob Storage",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -164,6 +164,13 @@ export const spanish: IAppStrings = {
             saveSuccess: "${connection.name} guardado correctamente",
             deleteSuccess: "${connection.name} eliminado correctamente",
         },
+        imageCorsWarning: "Advertencia: Cuando se usa VoTT en un navegador web, es posible que algunos activos de este \
+                          Búsqueda de Imágenes Bing no se exporten correctamente debido a las restricciones de CORS \
+                          (Recursos de Origen Cruzado).",
+        blobCorsWarning: "Advertencia: CORS (Recursos de Origen Cruzado) debe estar habilitado en la \
+                          cuenta de Azure Blob Storage para poder usarlo como una conexión de origen o destino. Puede \
+                          encontrar más información sobre cómo habilitar CORS en la {0}.",
+        azDocLinkText: "documentación de Azure.",
         providers: {
             azureBlob: {
                 title: "Azure Blob Storage",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -165,6 +165,9 @@ export interface IAppStrings {
             saveSuccess: string;
             deleteSuccess: string;
         },
+        imageCorsWarning: string;
+        blobCorsWarning: string;
+        azDocLinkText: string;
         providers: {
             azureBlob: {
                 title: string;

--- a/src/react/components/pages/connections/connectionForm.test.tsx
+++ b/src/react/components/pages/connections/connectionForm.test.tsx
@@ -3,6 +3,11 @@ import { mount, ReactWrapper } from "enzyme";
 import MockFactory from "../../../../common/mockFactory";
 import ConnectionForm, { IConnectionFormProps, IConnectionFormState } from "./connectionForm";
 
+jest.mock("../../../../common/hostProcess", () => ({
+    isBrowser: jest.fn(),
+}));
+import { isBrowser } from "../../../../common/hostProcess";
+
 describe("Connection Form", () => {
     const onSubmitHandler = jest.fn();
     const testConnection = MockFactory.createTestConnection("test", "localFileSystemProxy");
@@ -45,6 +50,38 @@ describe("Connection Form", () => {
         expect("apiKey" in providerOptions).toBe(true);
         expect("query" in providerOptions).toBe(true);
         expect("aspectRatio" in providerOptions).toBe(true);
+    });
+
+    it("should display warning for Bing Image Search when running in a browser", async () => {
+        const isBrowserMock = isBrowser as jest.Mock;
+        isBrowserMock.mockReturnValue(true);
+
+        wrapper
+            .find("select#root_providerType")
+            .simulate("change", { target: { value: "bingImageSearch" } });
+
+        await MockFactory.flushUi();
+        wrapper.update();
+
+        const providerOptions = wrapper.state().formData.providerOptions;
+        expect(wrapper.state().formData.providerType).toEqual("bingImageSearch");
+        expect(wrapper.exists("div.alert")).toEqual(true);
+    });
+
+    it("should display warning for Blob Storage when running in a browser", async () => {
+        const isBrowserMock = isBrowser as jest.Mock;
+        isBrowserMock.mockReturnValue(true);
+
+        wrapper
+            .find("select#root_providerType")
+            .simulate("change", { target: { value: "azureBlobStorage" } });
+
+        await MockFactory.flushUi();
+        wrapper.update();
+
+        const providerOptions = wrapper.state().formData.providerOptions;
+        expect(wrapper.state().formData.providerType).toEqual("azureBlobStorage");
+        expect(wrapper.exists("div.alert")).toEqual(true);
     });
 
     it("should call the onSubmit event handler when the form is submitted", async () => {

--- a/src/react/components/pages/connections/connectionForm.tsx
+++ b/src/react/components/pages/connections/connectionForm.tsx
@@ -9,6 +9,7 @@ import { ProtectedInput } from "../../common/protectedInput/protectedInput";
 import Checkbox from "rc-checkbox";
 import "rc-checkbox/assets/index.css";
 import { CustomWidget } from "../../common/customField/customField";
+import { isBrowser } from "../../../../common/hostProcess";
 // tslint:disable-next-line:no-var-requires
 const formSchema = addLocValues(require("./connectionForm.json"));
 // tslint:disable-next-line:no-var-requires
@@ -93,6 +94,21 @@ export default class ConnectionForm extends React.Component<IConnectionFormProps
                     </span>
                 </h3>
                 <div className="m-3">
+                    { isBrowser() && this.state.providerName === "bingImageSearch" &&
+                    <div className="alert alert-warning" role="alert">
+                        <i className="fas fa-exclamation-circle mr-1" aria-hidden="true"></i>
+                        { strings.connections.imageCorsWarning }
+                    </div>
+                    }
+                    { isBrowser() && this.state.providerName === "azureBlobStorage" &&
+                    <div className="alert alert-warning" role="alert">
+                        <i className="fas fa-exclamation-circle mr-1" aria-hidden="true"></i>
+                        { strings.formatString(
+                            strings.connections.blobCorsWarning,
+                            <a href="https://aka.ms/blob-cors" target="_blank">{strings.connections.azDocLinkText}</a>)
+                        }
+                    </div>
+                    }
                     <Form
                         className={this.state.classNames.join(" ")}
                         showErrorList={false}


### PR DESCRIPTION
Error message displays when adding a Bing Image Search asset provider
type. This is only applicable for the Browser target.

[AB#17153](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=17153)