### PR TITLE
feat: Auto-size video/image assets and position canvas

### DIFF
--- a/src/common/layout.test.tsx
+++ b/src/common/layout.test.tsx
@@ -1,0 +1,128 @@
+import { createContentBoundingBox, createLandscapeBoundingBox, createPortraitBoundingBox } from "./layout";
+import { IGenericContentSource } from "../react/components/common/assetPreview/assetPreview";
+
+describe("Layout Utils", () => {
+    describe("createLandscapeBoundingBox", () => {
+        it("creates a landscape sized bounding box", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 1080,
+                offsetHeight: 1080,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 800,
+                height: 450,
+            };
+
+            const aspectRatio = contentSource.width / contentSource.height;
+
+            const result = createLandscapeBoundingBox(contentSource, aspectRatio);
+            expect(result).toEqual({
+                width: 1080,
+                height: 607.5,
+                top: 236.25,
+                left: 0,
+            });
+        });
+    });
+
+    describe("createPortraitBoundingBox", () => {
+        it("creates a portrait sized bounding box", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 1080,
+                offsetHeight: 1080,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 600,
+                height: 800,
+            };
+
+            const aspectRatio = contentSource.width / contentSource.height;
+
+            const result = createPortraitBoundingBox(contentSource, aspectRatio);
+            expect(result).toEqual({
+                width: 810,
+                height: 1080,
+                top: 0,
+                left: 135,
+            });
+        });
+    });
+
+    describe("createContentBoundingBox", () => {
+        it("creates landscape sized bounding box for landscape image", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 1080,
+                offsetHeight: 1080,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 800,
+                height: 450,
+            };
+
+            const result = createContentBoundingBox(contentSource);
+            expect(result).toEqual({
+                width: 1080,
+                height: 607.5,
+                top: 236.25,
+                left: 0,
+            });
+        });
+
+        it("creates portrait sized bounding box for landscape image", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 1000,
+                offsetHeight: 400,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 800,
+                height: 450,
+            };
+
+            const result = createContentBoundingBox(contentSource);
+            expect(result).toEqual({
+                width: 711.1111111111111,
+                height: 400,
+                top: 0,
+                left: 144.44444444444446,
+            });
+        });
+
+        it("creates portrait sized bounding box for portrait image", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 1080,
+                offsetHeight: 1080,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 450,
+                height: 800,
+            };
+
+            const result = createContentBoundingBox(contentSource);
+            expect(result).toEqual({
+                width: 607.5,
+                height: 1080,
+                top: 0,
+                left: 236.25,
+            });
+        });
+
+        it("creates landscape sized bounding box for portrait image", () => {
+            const contentSource: IGenericContentSource = {
+                offsetWidth: 300,
+                offsetHeight: 800,
+                offsetTop: 0,
+                offsetLeft: 0,
+                width: 300,
+                height: 400,
+            };
+
+            const result = createContentBoundingBox(contentSource);
+            expect(result).toEqual({
+                width: 300,
+                height: 400,
+                top: 200,
+                left: 0,
+            });
+        });
+    });
+});

--- a/src/common/layout.ts
+++ b/src/common/layout.ts
@@ -1,0 +1,92 @@
+import { ContentSource } from "../react/components/common/assetPreview/assetPreview";
+import { IBoundingBox, ISize } from "../models/applicationState";
+import Guard from "./guard";
+
+/**
+ * Gets the current position of the specified content source
+ * @param contentSource The HTML element to get position
+ */
+export function createContentBoundingBox(contentSource: ContentSource): IBoundingBox {
+    Guard.null(contentSource);
+
+    let aspectRatio: number = null;
+    if (contentSource instanceof HTMLVideoElement) {
+        aspectRatio = contentSource.videoWidth / contentSource.videoHeight;
+    } else if (contentSource instanceof HTMLImageElement) {
+        aspectRatio = contentSource.naturalWidth / contentSource.naturalHeight;
+    } else {
+        aspectRatio = contentSource.width / contentSource.height;
+    }
+
+    let size: ISize = null;
+
+    // Landscape = aspectRatio > 1
+    // Portrait  = aspectRatio < 1
+    if (aspectRatio >= 1) {
+        size = {
+            width: contentSource.offsetWidth,
+            height: contentSource.offsetWidth / aspectRatio,
+        };
+
+        // Render as landscape except for when the calculated height
+        // would be taller than the available area
+        return size.height > contentSource.offsetHeight
+            ? createPortraitBoundingBox(contentSource, aspectRatio)
+            : createLandscapeBoundingBox(contentSource, aspectRatio);
+    } else {
+        size = {
+            width: contentSource.offsetHeight * aspectRatio,
+            height: contentSource.offsetHeight,
+        };
+
+        // Render as portrait except for when the calculated width
+        // would be wider then the available area
+        return size.width > contentSource.offsetWidth
+            ? createLandscapeBoundingBox(contentSource, aspectRatio)
+            : createPortraitBoundingBox(contentSource, aspectRatio);
+    }
+}
+
+/**
+ * Gets a landscape bounding box for the canvas element based on the content source and aspect ratio
+ * Disregards generated bars from the browser
+ * @param contentSource The HTML content element
+ * @param aspectRatio The requested aspect ratio
+ */
+export function createLandscapeBoundingBox(contentSource: ContentSource, aspectRatio: number): IBoundingBox {
+    Guard.null(contentSource);
+    Guard.expression(aspectRatio, (value) => value > 0);
+
+    const size = {
+        width: contentSource.offsetWidth,
+        height: contentSource.offsetWidth / aspectRatio,
+    };
+    return {
+        width: size.width,
+        height: size.height,
+        left: contentSource.offsetLeft,
+        top: contentSource.offsetTop + ((contentSource.offsetHeight - size.height) / 2),
+    };
+}
+
+/**
+ * Gets a portrait bounding box for the canvas element based on the content source and aspect ratio
+ * Disregards generated bars from the browser
+ * @param contentSource The HTML content element
+ * @param aspectRatio The requested aspect ratio
+ */
+export function createPortraitBoundingBox(contentSource: ContentSource, aspectRatio: number): IBoundingBox {
+    Guard.null(contentSource);
+    Guard.expression(aspectRatio, (value) => value > 0);
+
+    const size = {
+        width: contentSource.offsetHeight * aspectRatio,
+        height: contentSource.offsetHeight,
+    };
+    return {
+        width: size.width,
+        height: size.height,
+        left: contentSource.offsetLeft + ((contentSource.offsetWidth - size.width) / 2),
+        top: contentSource.offsetTop,
+    };
+}

--- a/src/common/layout.ts
+++ b/src/common/layout.ts
@@ -55,12 +55,12 @@ export function createContentBoundingBox(contentSource: ContentSource): IBoundin
  */
 export function createLandscapeBoundingBox(contentSource: ContentSource, aspectRatio: number): IBoundingBox {
     Guard.null(contentSource);
-    Guard.expression(aspectRatio, (value) => value > 0);
 
     const size = {
         width: contentSource.offsetWidth,
         height: contentSource.offsetWidth / aspectRatio,
     };
+
     return {
         width: size.width,
         height: size.height,
@@ -77,12 +77,12 @@ export function createLandscapeBoundingBox(contentSource: ContentSource, aspectR
  */
 export function createPortraitBoundingBox(contentSource: ContentSource, aspectRatio: number): IBoundingBox {
     Guard.null(contentSource);
-    Guard.expression(aspectRatio, (value) => value > 0);
 
     const size = {
         width: contentSource.offsetHeight * aspectRatio,
         height: contentSource.offsetHeight,
     };
+
     return {
         width: size.width,
         height: size.height,

--- a/src/react/components/common/assetPreview/assetPreview.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.tsx
@@ -5,7 +5,15 @@ import { ImageAsset } from "./imageAsset";
 import { VideoAsset } from "./videoAsset";
 import { TFRecordAsset } from "./tfrecordAsset";
 
-export type ContentSource = HTMLImageElement | HTMLVideoElement;
+export interface IGenericContentSource {
+    width: number;
+    height: number;
+    offsetWidth: number;
+    offsetHeight: number;
+    offsetTop: number;
+    offsetLeft: number;
+}
+export type ContentSource = HTMLImageElement | HTMLVideoElement | IGenericContentSource;
 
 /**
  * AssetPreview component properties

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -14,6 +14,7 @@ import Confirm from "../../common/confirm/confirm";
 import { strings } from "../../../../common/strings";
 import { SelectionMode } from "vott-ct/lib/js/CanvasTools/Interface/ISelectorSettings";
 import { Rect } from "vott-ct/lib/js/CanvasTools/Core/Rect";
+import { createContentBoundingBox } from "../../../../common/layout";
 
 export interface ICanvasProps extends React.Props<Canvas> {
     selectedAsset: IAssetMetadata;
@@ -445,7 +446,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
      */
     private setContentSource = async (contentSource: ContentSource) => {
         try {
-            await this.editor.addContentSource(contentSource);
+            await this.editor.addContentSource(contentSource as any);
         } catch (e) {
             console.warn(e);
         }
@@ -461,84 +462,13 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
         const canvas = this.canvasZone.current;
         if (canvas) {
-            const boundingBox = this.getContentPosition(contentSource);
+            const boundingBox = createContentBoundingBox(contentSource);
             canvas.style.top = `${boundingBox.top}px`;
             canvas.style.left = `${boundingBox.left}px`;
             canvas.style.width = `${boundingBox.width}px`;
             canvas.style.height = `${boundingBox.height}px`;
             this.editor.resize(boundingBox.width, boundingBox.height);
         }
-    }
-
-    private getContentPosition = (contentSource: ContentSource): IBoundingBox => {
-        let aspectRatio: number = null;
-        if (contentSource instanceof HTMLVideoElement) {
-            aspectRatio = contentSource.videoWidth / contentSource.videoHeight;
-        } else if (contentSource instanceof HTMLImageElement) {
-            aspectRatio = contentSource.naturalWidth / contentSource.naturalHeight;
-        }
-
-        let size: ISize = null;
-
-        // Landscape = aspectRatio > 1
-        // Portrait  = aspectRatio < 1
-        if (aspectRatio >= 1) {
-            size = {
-                width: contentSource.offsetWidth,
-                height: contentSource.offsetWidth / aspectRatio,
-            };
-
-            // Render as landscape except for when the calculated height
-            // would be taller than the available area
-            return size.height > contentSource.offsetHeight
-                ? this.getPortraitBoundingBox(aspectRatio, contentSource)
-                : this.getLandscapeBoundingBox(aspectRatio, contentSource);
-        } else {
-            size = {
-                width: contentSource.offsetHeight * aspectRatio,
-                height: contentSource.offsetHeight,
-            };
-
-            // Render as portrait except for when the calculated width
-            // would be wider then the available area
-            return size.width > contentSource.offsetWidth
-                ? this.getLandscapeBoundingBox(aspectRatio, contentSource)
-                : this.getPortraitBoundingBox(aspectRatio, contentSource);
-        }
-    }
-
-    /**
-     * Gets a landscape bounding box for the canvas element based on the content source and aspect ratio
-     * Disregards generated bars from the browser
-     */
-    private getLandscapeBoundingBox = (aspectRatio: number, contentSource: ContentSource): IBoundingBox => {
-        const size = {
-            width: contentSource.offsetWidth,
-            height: contentSource.offsetWidth / aspectRatio,
-        };
-        return {
-            width: size.width,
-            height: size.height,
-            left: contentSource.offsetLeft,
-            top: contentSource.offsetTop + ((contentSource.offsetHeight - size.height) / 2),
-        };
-    }
-
-    /**
-     * Gets a portrait bounding box for the canvas element based on the content source and aspect ratio
-     * Disregards generated bars from the browser
-     */
-    private getPortraitBoundingBox = (aspectRatio: number, contentSource: ContentSource): IBoundingBox => {
-        const size = {
-            width: contentSource.offsetHeight * aspectRatio,
-            height: contentSource.offsetHeight,
-        };
-        return {
-            width: size.width,
-            height: size.height,
-            left: contentSource.offsetLeft + ((contentSource.offsetWidth - size.width) / 2),
-            top: contentSource.offsetTop,
-        };
     }
 
     /**

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -60,7 +60,7 @@
 
       &-video {
         position: static;
-        width: auto;
+        width: 100%;
         height: calc(100% - 3em);
       }
 
@@ -161,9 +161,9 @@
   }
 
   img {
-    margin: auto;
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
   }
 
   &.portrait {
@@ -226,6 +226,7 @@
 #editor-zone {
   width: auto !important;
   padding: 0 !important;
+  height: 100% !important;
 }
 
 .full-size {


### PR DESCRIPTION
Normalizes the display of both image and video assets in VoTT.  `<video>` tags by default display with `object-fit: contain` which forces the video to always render in its correct aspect ratio.  The browser will automatically add horizontal / vertical bars as necessary based on fluid layouts.  This updates images to also use this same technique to preserve aspect ratio.  

The side effect however is having to manually calculate the actual asset content from within the HTML elements by detecting aspect ratio and computing correct offsets.