### PR TITLE
fix: Adjusts z-index video player overlays

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -72,7 +72,7 @@
           position: absolute;
           width: 100%;
           height: 100%;
-          z-index: 2;
+          z-index: 3;
         }
       }
     }
@@ -185,7 +185,6 @@
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
 
   .video-timeline {
     &-tagged,


### PR DESCRIPTION
A regression was introduced that caused the video timeline overlay to override the z-index of the player bar causing the player controls to not work as expected.  This resolves the issue by adjusting the z-index of both the player container as well as the disabled overlay for when controls are disabled.

Resolved [AB#18202](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=18202)