### PR TITLE
fix: don't allow invalid path characters in project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "rimraf": "^2.6.2",
         "shortid": "^2.2.14",
         "video-react": "^0.13.2",
-        "vott-ct": "^2.1.24",
+        "vott-ct": "2.1.24",
         "vott-react": "^0.2.10"
     },
     "scripts": {

--- a/src/react/components/pages/projectSettings/projectForm.json
+++ b/src/react/components/pages/projectSettings/projectForm.json
@@ -3,7 +3,8 @@
     "properties": {
         "name": {
             "title": "${strings.common.displayName}",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^\\\\\\\\/:*?\\\\\\\"<>|]*$"
         },
         "securityToken": {
             "title": "${strings.projectSettings.securityToken.title}",


### PR DESCRIPTION
Regex now prevents invalid path characters (<>"/\\|?*) in project
names, since it is used in file system operations. Using reserved
characters for Windows, as it is a superset of OSX/Linux.

[AB#18204](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=18204)