### PR TITLE
fix: Updated keyboard manager to support meta (aka cmd) key

### DIFF
--- a/src/react/components/common/keyboardBinding/keyboardBinding.test.tsx
+++ b/src/react/components/common/keyboardBinding/keyboardBinding.test.tsx
@@ -11,7 +11,7 @@ describe("Keyboard Binding Component", () => {
     const onKeyDownHandler = jest.fn();
     const deregisterFunc = jest.fn();
 
-    const accelerators = ["Ctrl+1"];
+    const accelerators = ["CmdOrCtrl+1"];
     const defaultProps: IKeyboardBindingProps = {
         displayName: "Keyboard binding",
         keyEventType: KeyEventType.KeyDown,

--- a/src/react/components/common/keyboardManager/keyboardManager.test.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.test.tsx
@@ -44,7 +44,7 @@ describe("Keyboard Manager Component", () => {
         expect(wrapper.find(".child").exists()).toBe(true);
     });
 
-    it("listens for Ctrl+ keydown events and invokes handlers", () => {
+    it("listens for CmdOrCtrl+ keydown events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyDown, {
                 ctrlKey: true,
@@ -54,10 +54,10 @@ describe("Keyboard Manager Component", () => {
         window.dispatchEvent(keyboardEvent);
 
         expect(registrationManagerMock.prototype.invokeHandler)
-            .toBeCalledWith(KeyEventType.KeyDown, "Ctrl+1", keyboardEvent);
+            .toBeCalledWith(KeyEventType.KeyDown, "CmdOrCtrl+1", keyboardEvent);
     });
 
-    it("listens for Ctrl+ keyup events and invokes handlers", () => {
+    it("listens for CmdOrCtrl+ keyup events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyUp, {
                 ctrlKey: true,
@@ -67,10 +67,10 @@ describe("Keyboard Manager Component", () => {
         window.dispatchEvent(keyboardEvent);
 
         expect(registrationManagerMock.prototype.invokeHandler)
-            .toBeCalledWith(KeyEventType.KeyUp, "Ctrl+1", keyboardEvent);
+            .toBeCalledWith(KeyEventType.KeyUp, "CmdOrCtrl+1", keyboardEvent);
     });
 
-    it("listens for Ctrl+ keypress events and invokes handlers", () => {
+    it("listens for CmdOrCtrl+ keypress events and invokes handlers", () => {
         const keyboardEvent = new KeyboardEvent(
             KeyEventType.KeyPress, {
                 ctrlKey: true,
@@ -80,7 +80,7 @@ describe("Keyboard Manager Component", () => {
         window.dispatchEvent(keyboardEvent);
 
         expect(registrationManagerMock.prototype.invokeHandler)
-            .toBeCalledWith(KeyEventType.KeyPress, "Ctrl+1", keyboardEvent);
+            .toBeCalledWith(KeyEventType.KeyPress, "CmdOrCtrl+1", keyboardEvent);
     });
 
     it("listens for Alt+ keydown events and invokes handlers", () => {

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -48,8 +48,8 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
 
     private getKeyParts(evt: KeyboardEvent) {
         const keyParts = [];
-        if (evt.ctrlKey) {
-            keyParts.push("Ctrl+");
+        if (evt.ctrlKey || evt.metaKey) {
+            keyParts.push("CmdOrCtrl+");
         }
         if (evt.altKey) {
             keyParts.push("Alt+");

--- a/src/react/components/common/keyboardManager/keyboardManager.tsx
+++ b/src/react/components/common/keyboardManager/keyboardManager.tsx
@@ -23,7 +23,7 @@ export class KeyboardManager extends React.Component<any, IKeyboardContext> {
         keyboard: new KeyboardRegistrationManager(),
     };
 
-    private nonSupportedKeys = new Set(["Ctrl", " Control", "Alt"]);
+    private nonSupportedKeys = new Set(["Meta", "Ctrl", " Control", "Alt"]);
     private inputElementTypes = new Set(["input", "select", "textarea"]);
 
     public componentDidMount() {

--- a/src/react/components/common/keyboardManager/keyboardRegistrationManager.test.ts
+++ b/src/react/components/common/keyboardManager/keyboardRegistrationManager.test.ts
@@ -26,9 +26,9 @@ describe("Keyboard Registration Manager", () => {
     });
 
     it("can add keyboard event handlers", () => {
-        const keyCode1 = "Ctrl+1";
+        const keyCode1 = "CmdOrCtrl+1";
         const handler1 = (evt: KeyboardEvent) => null;
-        const keyCode2 = "Ctrl+S";
+        const keyCode2 = "CmdOrCtrl+S";
         const handler2 = (evt: KeyboardEvent) => null;
 
         addHandler(keyboardManager, KeyEventType.KeyDown, [keyCode1], handler1);
@@ -42,7 +42,7 @@ describe("Keyboard Registration Manager", () => {
     });
 
     it("can register handlers for same key code and different key event types", () => {
-        const keyCodeString = "Ctrl+H";
+        const keyCodeString = "CmdOrCtrl+H";
         const keyCodes = [keyCodeString];
         const keyDownHandler = (evt: KeyboardEvent) => null;
         const keyUpHandler = (evt: KeyboardEvent) => null;
@@ -60,7 +60,7 @@ describe("Keyboard Registration Manager", () => {
     });
 
     it("throws error when trying to register multiple handlers for same key code", () => {
-        const keyCode = "Ctrl+H";
+        const keyCode = "CmdOrCtrl+H";
         const handler1 = (evt: KeyboardEvent) => null;
         const handler2 = (evt: KeyboardEvent) => null;
 
@@ -69,7 +69,7 @@ describe("Keyboard Registration Manager", () => {
     });
 
     it("can remove keyboard event handlers", () => {
-        const keyCode = "Ctrl+1";
+        const keyCode = "CmdOrCtrl+1";
 
         // Register keyboard handler
         const deregister = addHandler(keyboardManager, KeyEventType.KeyDown, [keyCode], jest.fn());
@@ -93,8 +93,8 @@ describe("Keyboard Registration Manager", () => {
 
     describe("array with mulitple keyCodes", () => {
         it("register all keycodes with the same eventType and handler", () => {
-            const keyCode1 = "Ctrl+1";
-            const keyCode2 = "Ctrl+S";
+            const keyCode1 = "CmdOrCtrl+1";
+            const keyCode2 = "CmdOrCtrl+S";
             const keyCodes = [keyCode1, keyCode2];
             const handler = jest.fn();
 
@@ -105,7 +105,7 @@ describe("Keyboard Registration Manager", () => {
         });
 
         it("invoke the registered keyboard handlers", () => {
-            const keyCode1 = "Ctrl+1";
+            const keyCode1 = "CmdOrCtrl+1";
             const keyCode2 = "ArrowUp";
             const keyCodes = [keyCode1, keyCode2];
             const handler = jest.fn();
@@ -129,8 +129,8 @@ describe("Keyboard Registration Manager", () => {
         });
 
         it("correctly remove all associated handlers", () => {
-            const keyCode1 = "Ctrl+1";
-            const keyCode2 = "Ctrl+S";
+            const keyCode1 = "CmdOrCtrl+1";
+            const keyCode2 = "CmdOrCtrl+S";
             const keyCodes = [keyCode1, keyCode2];
             const handler = (evt: KeyboardEvent) => null;
 

--- a/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
+++ b/src/react/components/common/keyboardManager/keyboardRegistrationManager.ts
@@ -61,7 +61,7 @@ export class KeyboardRegistrationManager {
     /**
      * Gets a list of registered event handlers for the specified key code
      * @param keyEventType Type of key event (keydown, keyup, keypress)
-     * @param keyCode The key code combination, ex) Ctrl+1
+     * @param keyCode The key code combination, ex) CmdOrCtrl+1
      */
     public getHandler(keyEventType: KeyEventType, keyCode: string): (evt?: KeyboardEvent) => void {
         Guard.null(keyEventType);
@@ -78,7 +78,7 @@ export class KeyboardRegistrationManager {
     /**
      * Invokes all registered event handlers for the specified key code\
      * @param keyEventType Type of key event (keydown, keyup, keypress)
-     * @param keyCode The key code combination, ex) Ctrl+1
+     * @param keyCode The key code combination, ex) CmdOrCtrl+1
      * @param evt The keyboard event that was raised
      */
     public invokeHandler(keyEventType: KeyEventType, keyCode: string, evt: KeyboardEvent) {

--- a/src/react/components/common/tagInput/tagInputItem.tsx
+++ b/src/react/components/common/tagInput/tagInputItem.tsx
@@ -95,7 +95,7 @@ export default class TagInputItem extends React.Component<ITagInputItemProps, IT
     private onColorClick = (e: MouseEvent) => {
         e.stopPropagation();
 
-        const ctrlKey = e.ctrlKey;
+        const ctrlKey = e.ctrlKey || e.metaKey;
         const altKey = e.altKey;
         this.setState({
             tagEditMode: TagEditMode.Color,
@@ -105,7 +105,7 @@ export default class TagInputItem extends React.Component<ITagInputItemProps, IT
     private onNameClick = (e: MouseEvent) => {
         e.stopPropagation();
 
-        const ctrlKey = e.ctrlKey;
+        const ctrlKey = e.ctrlKey || e.metaKey;
         const altKey = e.altKey;
         this.setState({
             tagEditMode: TagEditMode.Name,

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -582,22 +582,22 @@ describe("Editor Page Component", () => {
         });
 
         it("Calls copy regions with hot key", () => {
-            dispatchKeyEvent("Ctrl+c");
+            dispatchKeyEvent("CmdOrCtrl+c");
             expect(copyRegions).toBeCalled();
         });
 
         it("Calls cut regions with hot key", () => {
-            dispatchKeyEvent("Ctrl+x");
+            dispatchKeyEvent("CmdOrCtrl+x");
             expect(cutRegions).toBeCalled();
         });
 
         it("Calls paste regions with hot key", () => {
-            dispatchKeyEvent("Ctrl+v");
+            dispatchKeyEvent("CmdOrCtrl+v");
             expect(pasteRegions).toBeCalled();
         });
 
         it("Calls remove all regions confirmation with hot key", () => {
-            dispatchKeyEvent("Ctrl+Delete");
+            dispatchKeyEvent("CmdOrCtrl+Delete");
             expect(removeAllRegionsConfirm).toBeCalled();
         });
 
@@ -618,7 +618,7 @@ describe("Editor Page Component", () => {
             expect(editorPage.state().selectedTag).toEqual(project.tags[0].name);
         });
 
-        it("sets selected tag and locked tags when ctrl + hot key is pressed", async () => {
+        it("sets selected tag and locked tags when CmdOrCtrl + hot key is pressed", async () => {
             const project = MockFactory.createTestProject("test", 5);
             const store = createReduxStore({
                 ...MockFactory.initialState(),
@@ -630,7 +630,7 @@ describe("Editor Page Component", () => {
 
             expect(editorPage.state().selectedTag).toBeNull();
 
-            dispatchKeyEvent("Ctrl+1");
+            dispatchKeyEvent("CmdOrCtrl+1");
 
             const firstTag = project.tags[0].name;
             expect(editorPage.state().selectedTag).toEqual(firstTag);
@@ -705,7 +705,7 @@ describe("Editor Page Component", () => {
             expect(stateTags).toHaveLength(project.tags.length - 1);
         });
 
-        it("Adds tag to locked tags when ctrl clicked", async () => {
+        it("Adds tag to locked tags when CmdOrCtrl clicked", async () => {
             const project = MockFactory.createTestProject();
             const store = createReduxStore({
                 ...MockFactory.initialState(),

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -172,7 +172,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         displayName={strings.editorPage.tags.hotKey.lock}
                         key={index}
                         keyEventType={KeyEventType.KeyDown}
-                        accelerators={[`Ctrl+${index}`]}
+                        accelerators={[`CmdOrCtrl+${index}`]}
                         icon={"fa-lock"}
                         handler={this.handleCtrlTagHotKey} />);
                 })}

--- a/src/react/components/shell/helpMenu.tsx
+++ b/src/react/components/shell/helpMenu.tsx
@@ -28,7 +28,7 @@ export class HelpMenu extends React.Component<IHelpMenuProps, IHelpMenuState> {
                 <i className={`fas ${this.icon}`}/>
                 <KeyboardBinding
                     displayName={strings.editorPage.help.title}
-                    accelerators={["Ctrl+H", "Ctrl+h"]}
+                    accelerators={["CmdOrCtrl+H", "CmdOrCtrl+h"]}
                     handler={() => this.setState({show: !this.state.show})}
                     icon={this.icon}
                     keyEventType={KeyEventType.KeyDown}

--- a/src/react/components/toolbar/toolbarItem.test.tsx
+++ b/src/react/components/toolbar/toolbarItem.test.tsx
@@ -59,7 +59,7 @@ describe("Toolbar Item", () => {
 
     it("Renders a keyboard binding when an accelerator is configured", () => {
         const props = createProps();
-        props.accelerators = ["Ctrl+1"];
+        props.accelerators = ["CmdOrCtrl+1"];
 
         const wrapper = createComponent(props);
         expect(wrapper.find(KeyboardBinding).exists()).toBe(true);

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -99,7 +99,7 @@ export default function registerToolbar() {
         icon: "fa-ban",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["CmdOrCtrl+Delete"],
+        accelerators: ["CmdOrCtrl+Delete", "CmdOrCtrl+Backspace"],
     });
 
     ToolbarItemFactory.register({

--- a/src/registerToolbar.ts
+++ b/src/registerToolbar.ts
@@ -63,7 +63,7 @@ export default function registerToolbar() {
         icon: "far fa-clone",
         group: ToolbarItemGroup.Canvas,
         type: ToolbarItemType.State,
-        accelerators: ["Ctrl+W", "Ctrl+w"],
+        accelerators: ["CmdOrCtrl+W", "CmdOrCtrl+w"],
     });
 
     ToolbarItemFactory.register({
@@ -72,7 +72,7 @@ export default function registerToolbar() {
         icon: "fa-copy",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+C", "Ctrl+c"],
+        accelerators: ["CmdOrCtrl+C", "CmdOrCtrl+c"],
     });
 
     ToolbarItemFactory.register({
@@ -81,7 +81,7 @@ export default function registerToolbar() {
         icon: "fa-cut",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+X", "Ctrl+x"],
+        accelerators: ["CmdOrCtrl+X", "CmdOrCtrl+x"],
     });
 
     ToolbarItemFactory.register({
@@ -90,7 +90,7 @@ export default function registerToolbar() {
         icon: "fa-paste",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+V", "Ctrl+v"],
+        accelerators: ["CmdOrCtrl+V", "CmdOrCtrl+v"],
     });
 
     ToolbarItemFactory.register({
@@ -99,7 +99,7 @@ export default function registerToolbar() {
         icon: "fa-ban",
         group: ToolbarItemGroup.Regions,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+Delete"],
+        accelerators: ["CmdOrCtrl+Delete"],
     });
 
     ToolbarItemFactory.register({
@@ -126,7 +126,7 @@ export default function registerToolbar() {
         icon: "fa-save",
         group: ToolbarItemGroup.Project,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+S", "Ctrl+s"],
+        accelerators: ["CmdOrCtrl+S", "CmdOrCtrl+s"],
     }, SaveProject);
 
     ToolbarItemFactory.register({
@@ -135,6 +135,6 @@ export default function registerToolbar() {
         icon: "fa-external-link-square-alt",
         group: ToolbarItemGroup.Project,
         type: ToolbarItemType.Action,
-        accelerators: ["Ctrl+E", "Ctrl+e"],
+        accelerators: ["CmdOrCtrl+E", "CmdOrCtrl+e"],
     }, ExportProject);
 }


### PR DESCRIPTION
Resolves an issue where normal Cmd+ keyboard shortcuts that typically work on Mac OSX don't work in VoTT.  The fix treats Ctrl or Cmd to be equivalent and also checks the value of the "meta" key within keyboard events.

Resolves [AB#18159](https://dev.azure.com/dwrdev/web/wi.aspx?pcguid=80f9922c-b416-454c-92c6-ab7b6867e0b2&id=18159)