### PR TITLE
fix: change method for alloc string to buffer

### DIFF
--- a/src/electron/providers/storage/localFileSystem.test.ts
+++ b/src/electron/providers/storage/localFileSystem.test.ts
@@ -23,6 +23,7 @@ describe("LocalFileSystem Storage Provider", () => {
             a: 1,
             b: 2,
             c: 3,
+            d: "한글 中國 にほんご",
         };
 
         await localFileSystem.writeText(filePath, JSON.stringify(contents, null, 4));

--- a/src/electron/providers/storage/localFileSystem.ts
+++ b/src/electron/providers/storage/localFileSystem.ts
@@ -71,7 +71,7 @@ export default class LocalFileSystem implements IStorageProvider {
     }
 
     public writeText(filePath: string, contents: string): Promise<void> {
-        const buffer = Buffer.alloc(contents.length, contents);
+        const buffer = Buffer.from(contents);
         return this.writeBinary(filePath, buffer);
     }
 


### PR DESCRIPTION
Fix #776 

String.length is not appropriate for calculating buffer size when non-alphabet letter is included in content.
Change the method Buffer.alloc to Buffer.from as directed by the nodejs document.