### PR TITLE
feat: Hash asset IDs with project name [AB#18063]

### DIFF
--- a/src/common/htmlFileReader.test.ts
+++ b/src/common/htmlFileReader.test.ts
@@ -114,7 +114,8 @@ describe("Html File Reader", () => {
         });
 
         it("Test non valid asset type", async () => {
-            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.notsupported", projectName);
+            const imageAsset = AssetService.createAssetFromFilePath(
+                "https://server.com/image.notsupported", projectName);
             try {
                 const result = await HtmlFileReader.readAssetAttributes(imageAsset);
             } catch (error) {

--- a/src/common/htmlFileReader.test.ts
+++ b/src/common/htmlFileReader.test.ts
@@ -187,7 +187,7 @@ describe("Html File Reader", () => {
 
     describe("Extracting video frames", () => {
         it("Gets a blob for the requested video frame", async () => {
-            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-1", AssetState.Tagged);
+            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-1", projectName, AssetState.Tagged);
             const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 123.456, projectName);
             assetTestCache.set(videoFrame.parent.path, videoFrame);
 
@@ -197,7 +197,7 @@ describe("Html File Reader", () => {
         });
 
         it("Appends jpg file extension on specified video frame asset", async () => {
-            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-2", AssetState.Tagged);
+            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-2", projectName, AssetState.Tagged);
             const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789, projectName);
             assetTestCache.set(videoFrame.parent.path, videoFrame);
 
@@ -207,7 +207,7 @@ describe("Html File Reader", () => {
         });
 
         it("Does not duplicate jpg file extension on specified video frame asset", async () => {
-            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-3", AssetState.Tagged);
+            const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-3", projectName, AssetState.Tagged);
             const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789, projectName);
             videoFrame.name += ".jpg";
             assetTestCache.set(videoFrame.parent.path, videoFrame);
@@ -219,7 +219,7 @@ describe("Html File Reader", () => {
         });
 
         it("Throws an error when a video error occurs", async () => {
-            const videoErrorAsset = MockFactory.createVideoTestAsset("VideoErrorAsset", AssetState.Tagged);
+            const videoErrorAsset = MockFactory.createVideoTestAsset("VideoErrorAsset", projectName, AssetState.Tagged);
             const videoErrorFrame = MockFactory.createChildVideoAsset(videoErrorAsset, 123.456, projectName);
             assetTestCache.set(videoErrorAsset.path, videoErrorFrame);
 

--- a/src/common/htmlFileReader.test.ts
+++ b/src/common/htmlFileReader.test.ts
@@ -8,6 +8,8 @@ import { AssetState, IAsset } from "../models/applicationState";
 describe("Html File Reader", () => {
     const assetTestCache = new Map<string, IAsset>();
 
+    const projectName = "test";
+
     beforeEach(() => {
         assetTestCache.clear();
         MockFactory.mockElement(assetTestCache);
@@ -27,7 +29,7 @@ describe("Html File Reader", () => {
     });
 
     it("Loads attributes for HTML 5 video", async () => {
-        const videoAsset = AssetService.createAssetFromFilePath("https://server.com/video.mp4");
+        const videoAsset = AssetService.createAssetFromFilePath("https://server.com/video.mp4", projectName);
         videoAsset.size = {
             width: 1920,
             height: 1080,
@@ -41,7 +43,7 @@ describe("Html File Reader", () => {
     });
 
     it("Loads attributes for an image asset", async () => {
-        const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.jpg");
+        const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.jpg", projectName);
         imageAsset.size = {
             width: 1920,
             height: 1080,
@@ -56,7 +58,7 @@ describe("Html File Reader", () => {
 
     describe("Download asset binaries", () => {
         it("Downloads a blob from the asset path", async () => {
-            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg");
+            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg", projectName);
             axios.get = jest.fn((url, config) => {
                 return Promise.resolve<AxiosResponse>({
                     config,
@@ -74,7 +76,7 @@ describe("Html File Reader", () => {
         });
 
         it("Rejects the promise when request receives non 200 result", async () => {
-            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg");
+            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg", projectName);
             axios.get = jest.fn((url, config) => {
                 return Promise.resolve<AxiosResponse>({
                     config,
@@ -104,7 +106,7 @@ describe("Html File Reader", () => {
         });
 
         it("Downloads a byte array from the asset path", async () => {
-            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg");
+            const asset = AssetService.createAssetFromFilePath("https://server.com/image.jpg", projectName);
             const result = await HtmlFileReader.getAssetArray(asset);
             expect(result).not.toBeNull();
             expect(result).toBeInstanceOf(ArrayBuffer);
@@ -112,7 +114,7 @@ describe("Html File Reader", () => {
         });
 
         it("Test non valid asset type", async () => {
-            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.notsupported");
+            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.notsupported", projectName);
             try {
                 const result = await HtmlFileReader.readAssetAttributes(imageAsset);
             } catch (error) {
@@ -144,7 +146,7 @@ describe("Html File Reader", () => {
                 });
             });
 
-            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord");
+            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord", projectName);
             const result = await HtmlFileReader.readAssetAttributes(imageAsset);
 
             expect(result.width).toEqual(expected.width);
@@ -175,7 +177,7 @@ describe("Html File Reader", () => {
                 });
             });
 
-            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord");
+            const imageAsset = AssetService.createAssetFromFilePath("https://server.com/image.tfrecord", projectName);
             const result = await HtmlFileReader.readAssetAttributes(imageAsset);
 
             expect(result.width).toEqual(expected.width);
@@ -186,7 +188,7 @@ describe("Html File Reader", () => {
     describe("Extracting video frames", () => {
         it("Gets a blob for the requested video frame", async () => {
             const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-1", AssetState.Tagged);
-            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 123.456);
+            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 123.456, projectName);
             assetTestCache.set(videoFrame.parent.path, videoFrame);
 
             const blob = await HtmlFileReader.getAssetFrameImage(videoFrame);
@@ -196,7 +198,7 @@ describe("Html File Reader", () => {
 
         it("Appends jpg file extension on specified video frame asset", async () => {
             const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-2", AssetState.Tagged);
-            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789);
+            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789, projectName);
             assetTestCache.set(videoFrame.parent.path, videoFrame);
 
             expect(videoFrame.name.endsWith(".jpg")).toBe(false);
@@ -206,7 +208,7 @@ describe("Html File Reader", () => {
 
         it("Does not duplicate jpg file extension on specified video frame asset", async () => {
             const videoAsset = MockFactory.createVideoTestAsset("VideoTestAsset-3", AssetState.Tagged);
-            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789);
+            const videoFrame = MockFactory.createChildVideoAsset(videoAsset, 456.789, projectName);
             videoFrame.name += ".jpg";
             assetTestCache.set(videoFrame.parent.path, videoFrame);
 
@@ -218,7 +220,7 @@ describe("Html File Reader", () => {
 
         it("Throws an error when a video error occurs", async () => {
             const videoErrorAsset = MockFactory.createVideoTestAsset("VideoErrorAsset", AssetState.Tagged);
-            const videoErrorFrame = MockFactory.createChildVideoAsset(videoErrorAsset, 123.456);
+            const videoErrorFrame = MockFactory.createChildVideoAsset(videoErrorAsset, 123.456, projectName);
             assetTestCache.set(videoErrorAsset.path, videoErrorFrame);
 
             await expect(HtmlFileReader.getAssetFrameImage(videoErrorFrame)).rejects.not.toBeNull();

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -171,9 +171,10 @@ export default class MockFactory {
      * @param name Name of asset
      * @param assetState State of asset
      */
-    public static createVideoTestAsset(name: string, assetState: AssetState = AssetState.NotVisited): IAsset {
+    public static createVideoTestAsset(name: string, projectName: string, assetState: AssetState = AssetState.NotVisited): IAsset {
         return {
             id: `videoasset-${name}`,
+            projectName,
             format: "mp4",
             name: `videoasset${name}`,
             path: encodeFileURI(`C:\\Desktop\\videoasset${name}.mp4`),
@@ -387,7 +388,6 @@ export default class MockFactory {
      */
     public static createAzureOptions(): IAzureCloudStorageOptions {
         return {
-            projectName: "myproject",
             accountName: "myaccount",
             containerName: "container0",
             sas: "sas",
@@ -548,7 +548,6 @@ export default class MockFactory {
      */
     public static createBingOptions(): IBingImageSearchOptions {
         return {
-            projectName: "myproject",
             apiKey: "key",
             aspectRatio: BingImageSearchAspectRatio.All,
             query: "test",

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -191,9 +191,9 @@ export default class MockFactory {
      * @param rootAsset The parent video asset
      * @param timestamp The timestamp to generate child asset
      */
-    public static createChildVideoAsset(rootAsset: IAsset, timestamp: number): IAsset {
+    public static createChildVideoAsset(rootAsset: IAsset, timestamp: number, projectName: string): IAsset {
         const childPath = `${rootAsset.path}#t=${timestamp}`;
-        const childAsset = AssetService.createAssetFromFilePath(childPath);
+        const childAsset = AssetService.createAssetFromFilePath(childPath, projectName);
         childAsset.type = AssetType.VideoFrame;
         childAsset.state = AssetState.Tagged;
         childAsset.parent = rootAsset;

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -171,7 +171,8 @@ export default class MockFactory {
      * @param name Name of asset
      * @param assetState State of asset
      */
-    public static createVideoTestAsset(name: string, projectName: string, assetState: AssetState = AssetState.NotVisited): IAsset {
+    public static createVideoTestAsset(name: string, projectName: string,
+                                       assetState: AssetState = AssetState.NotVisited): IAsset {
         return {
             id: `videoasset-${name}`,
             projectName,
@@ -209,9 +210,9 @@ export default class MockFactory {
      * @param rootAsset The parent video asset
      * @param count The number of child assets to create (default 10)
      */
-    public static createChildVideoAssets(rootAsset: IAsset, count: number = 10): IAsset[] {
+    public static createChildVideoAssets(rootAsset: IAsset, count: number = 10, projectName="my project"): IAsset[] {
         return [...Array(count).keys()].map((index) => {
-            return this.createChildVideoAsset(rootAsset, index, "myproject");
+            return this.createChildVideoAsset(rootAsset, index, projectName);
         });
     }
 

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -210,7 +210,7 @@ export default class MockFactory {
      */
     public static createChildVideoAssets(rootAsset: IAsset, count: number = 10): IAsset[] {
         return [...Array(count).keys()].map((index) => {
-            return this.createChildVideoAsset(rootAsset, index);
+            return this.createChildVideoAsset(rootAsset, index, "myproject");
         });
     }
 
@@ -387,6 +387,7 @@ export default class MockFactory {
      */
     public static createAzureOptions(): IAzureCloudStorageOptions {
         return {
+            projectName: "myproject",
             accountName: "myaccount",
             containerName: "container0",
             sas: "sas",
@@ -547,6 +548,7 @@ export default class MockFactory {
      */
     public static createBingOptions(): IBingImageSearchOptions {
         return {
+            projectName: "myproject",
             apiKey: "key",
             aspectRatio: BingImageSearchAspectRatio.All,
             query: "test",

--- a/src/common/mockFactory.ts
+++ b/src/common/mockFactory.ts
@@ -210,7 +210,7 @@ export default class MockFactory {
      * @param rootAsset The parent video asset
      * @param count The number of child assets to create (default 10)
      */
-    public static createChildVideoAssets(rootAsset: IAsset, count: number = 10, projectName="my project"): IAsset[] {
+    public static createChildVideoAssets(rootAsset: IAsset, count: number = 10, projectName= "my project"): IAsset[] {
         return [...Array(count).keys()].map((index) => {
             return this.createChildVideoAsset(rootAsset, index, projectName);
         });

--- a/src/electron/providers/storage/localFileSystem.ts
+++ b/src/electron/providers/storage/localFileSystem.ts
@@ -136,9 +136,9 @@ export default class LocalFileSystem implements IStorageProvider {
         });
     }
 
-    public async getAssets(folderPath?: string): Promise<IAsset[]> {
+    public async getAssets(folderPath?: string, projectName?: string): Promise<IAsset[]> {
         return (await this.listFiles(path.normalize(folderPath)))
-            .map((filePath) => AssetService.createAssetFromFilePath(filePath))
+            .map((filePath) => AssetService.createAssetFromFilePath(filePath, projectName))
             .filter((asset) => asset.type !== AssetType.Unknown);
     }
 

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -264,6 +264,7 @@ export interface IAssetVideoSettings {
  */
 export interface IAsset {
     id: string;
+    projectName: string;
     type: AssetType;
     state: AssetState;
     name: string;

--- a/src/providers/export/azureCustomVision.test.ts
+++ b/src/providers/export/azureCustomVision.test.ts
@@ -38,6 +38,8 @@ describe("Azure Custom Vision Export Provider", () => {
         projectId: expect.any(String),
     };
 
+    const projectName = "my project";
+
     function createProvider(project: IProject): AzureCustomVisionProvider {
         return new AzureCustomVisionProvider(
             project,
@@ -210,7 +212,7 @@ describe("Azure Custom Vision Export Provider", () => {
         it("Uploads binaries, regions & tags for all assets", async () => {
             (testProject.exportFormat.providerOptions as IExportProviderOptions).assetState = ExportAssetState.All;
             const provider = createProvider(testProject);
-            const allAssets = await provider.getAssetsForExport();
+            const allAssets = await provider.getAssetsForExport(projectName);
             const taggedAssets = _.values(testProject.assets).filter((asset) => asset.state === AssetState.Tagged);
             const results = await provider.export();
 
@@ -274,7 +276,7 @@ describe("Azure Custom Vision Export Provider", () => {
         it("Returns export results", async () => {
             (testProject.exportFormat.providerOptions as IExportProviderOptions).assetState = ExportAssetState.All;
             const provider = createProvider(testProject);
-            const allAssets = await provider.getAssetsForExport();
+            const allAssets = await provider.getAssetsForExport(projectName);
             const results = await provider.export();
 
             expect(results.count).toEqual(allAssets.length);

--- a/src/providers/export/azureCustomVision.ts
+++ b/src/providers/export/azureCustomVision.ts
@@ -85,7 +85,7 @@ export class AzureCustomVisionProvider extends ExportProvider<IAzureCustomVision
      */
     public async export(): Promise<IExportResults> {
         const customVisionTags = await this.syncTags();
-        const assetsToExport = await this.getAssetsForExport();
+        const assetsToExport = await this.getAssetsForExport(this.project.name);
         const tagMap = _.keyBy(customVisionTags, "name");
 
         const results = await assetsToExport.mapAsync(async (asset) => {

--- a/src/providers/export/cntk.ts
+++ b/src/providers/export/cntk.ts
@@ -32,7 +32,7 @@ export class CntkExportProvider extends ExportProvider<ICntkExportProviderOption
 
     public async export(): Promise<IExportResults> {
         await this.createFolderStructure();
-        const assetsToExport = await this.getAssetsForExport();
+        const assetsToExport = await this.getAssetsForExport(this.project.name);
         const testSplit = (100 - (this.options.testTrainSplit || 80)) / 100;
         const testCount = Math.ceil(assetsToExport.length * testSplit);
         const testArray = assetsToExport.slice(0, testCount);

--- a/src/providers/export/exportProvider.test.ts
+++ b/src/providers/export/exportProvider.test.ts
@@ -65,7 +65,7 @@ describe("Export Provider Base", () => {
         });
 
         const exportProvider = ExportProviderFactory.create("test", testProject) as TestExportProvider;
-        const assetsToExport = await exportProvider.getAssetsForExport();
+        const assetsToExport = await exportProvider.getAssetsForExport(testProject.name);
         expect(assetsToExport.length).toEqual(testAssets.length);
     });
 
@@ -79,7 +79,7 @@ describe("Export Provider Base", () => {
         });
 
         const exportProvider = ExportProviderFactory.create("test", testProject) as TestExportProvider;
-        const assetsToExport = await exportProvider.getAssetsForExport();
+        const assetsToExport = await exportProvider.getAssetsForExport(testProject.name);
         const visitedAssets = _
             .values(testProject.assets)
             .filter((asset) => asset.state === AssetState.Visited || asset.state === AssetState.Tagged);
@@ -96,7 +96,7 @@ describe("Export Provider Base", () => {
         });
 
         const exportProvider = ExportProviderFactory.create("test", testProject) as TestExportProvider;
-        const assetsToExport = await exportProvider.getAssetsForExport();
+        const assetsToExport = await exportProvider.getAssetsForExport(testProject.name);
         const taggedAssets = _
             .values(testProject.assets)
             .filter((asset) => asset.state === AssetState.Tagged);

--- a/src/providers/export/exportProvider.ts
+++ b/src/providers/export/exportProvider.ts
@@ -70,7 +70,7 @@ export abstract class ExportProvider
     /**
      * Gets the assets that are configured to be exported based on the configured asset state
      */
-    public async getAssetsForExport(): Promise<IAssetMetadata[]> {
+    public async getAssetsForExport(projectName: string): Promise<IAssetMetadata[]> {
         let predicate: (asset: IAsset) => boolean = null;
 
         const getProjectAssets = () => Promise.resolve(_.values(this.project.assets));
@@ -78,7 +78,7 @@ export abstract class ExportProvider
             const projectAssets = await getProjectAssets();
 
             return _(projectAssets)
-                .concat((await this.assetProvider.getAssets()))
+                .concat((await this.assetProvider.getAssets(projectName)))
                 .uniqBy((asset) => asset.id)
                 .value();
         };

--- a/src/providers/export/pascalVOC.ts
+++ b/src/providers/export/pascalVOC.ts
@@ -47,7 +47,7 @@ export class PascalVOCExportProvider extends ExportProvider<IPascalVOCExportProv
      * Export project to PascalVOC
      */
     public async export(): Promise<void> {
-        const allAssets = await this.getAssetsForExport();
+        const allAssets = await this.getAssetsForExport(this.project.name);
         const exportObject: any = { ...this.project };
         exportObject.assets = _.keyBy(allAssets, (assetMetadata) => assetMetadata.asset.id);
 

--- a/src/providers/export/tensorFlowRecords.ts
+++ b/src/providers/export/tensorFlowRecords.ts
@@ -36,7 +36,7 @@ export class TFRecordsExportProvider extends ExportProvider {
      * Export project to TensorFlow Records
      */
     public async export(): Promise<void> {
-        const allAssets = await this.getAssetsForExport();
+        const allAssets = await this.getAssetsForExport(this.project.name);
         const exportObject: any = { ...this.project };
         exportObject.assets = _.keyBy(allAssets, (assetMetadata) => assetMetadata.asset.id);
 

--- a/src/providers/export/vottJson.ts
+++ b/src/providers/export/vottJson.ts
@@ -27,7 +27,7 @@ export class VottJsonExportProvider extends ExportProvider<IVottJsonExportProvid
      * Export project to VoTT JSON format
      */
     public async export(): Promise<void> {
-        const results = await this.getAssetsForExport();
+        const results = await this.getAssetsForExport(this.project.name);
 
         if (this.options.includeImages) {
             await results.forEachAsync(async (assetMetadata) => {

--- a/src/providers/storage/assetProviderFactory.ts
+++ b/src/providers/storage/assetProviderFactory.ts
@@ -9,7 +9,7 @@ import getHostProcess, { HostProcessType } from "../../common/hostProcess";
  */
 export interface IAssetProvider {
     initialize?(): Promise<void>;
-    getAssets(containerName?: string): Promise<IAsset[]>;
+    getAssets(projectName: string): Promise<IAsset[]>;
 }
 
 /**

--- a/src/providers/storage/azureBlobStorage.test.ts
+++ b/src/providers/storage/azureBlobStorage.test.ts
@@ -190,7 +190,7 @@ describe("Azure blob functions", () => {
             };
         });
         provider.getFileName = jest.fn();
-        const assets = await provider.getAssets();
+        const assets = await provider.getAssets("myproject");
         expect(provider.getFileName).toBeCalled();
         expect(assets).toHaveLength(ad.blobs.segment.blobItems.length);
     });

--- a/src/providers/storage/azureBlobStorage.test.ts
+++ b/src/providers/storage/azureBlobStorage.test.ts
@@ -190,7 +190,7 @@ describe("Azure blob functions", () => {
             };
         });
         provider.getFileName = jest.fn();
-        const assets = await provider.getAssets("myproject");
+        const assets = await provider.getAssets("my project");
         expect(provider.getFileName).toBeCalled();
         expect(assets).toHaveLength(ad.blobs.segment.blobItems.length);
     });

--- a/src/providers/storage/azureBlobStorage.ts
+++ b/src/providers/storage/azureBlobStorage.ts
@@ -16,6 +16,7 @@ import { BlobDeleteResponse } from "@azure/storage-blob/typings/lib/generated/li
  * @member oauthToken - Not yet implemented. Optional token for accessing Azure Blob Storage
  */
 export interface IAzureCloudStorageOptions {
+    projectName: string;
     accountName: string;
     containerName: string;
     createContainer: boolean;
@@ -191,13 +192,13 @@ export class AzureBlobStorage implements IStorageProvider {
      * @param containerName - Container from which to retrieve assets. Defaults to
      * container specified in Azure Cloud Storage options
      */
-    public async getAssets(containerName?: string, projectName?: string): Promise<IAsset[]> {
+    public async getAssets(containerName?: string): Promise<IAsset[]> {
         containerName = (containerName) ? containerName : this.options.containerName;
         const files = await this.listFiles(containerName);
         const result: IAsset[] = [];
         for (const file of files) {
             const url = this.getUrl(file);
-            const asset = AssetService.createAssetFromFilePath(url, projectName, this.getFileName(url));
+            const asset = AssetService.createAssetFromFilePath(url, this.options.projectName, this.getFileName(url));
             if (asset.type !== AssetType.Unknown) {
                 result.push(asset);
             }

--- a/src/providers/storage/azureBlobStorage.ts
+++ b/src/providers/storage/azureBlobStorage.ts
@@ -16,7 +16,6 @@ import { BlobDeleteResponse } from "@azure/storage-blob/typings/lib/generated/li
  * @member oauthToken - Not yet implemented. Optional token for accessing Azure Blob Storage
  */
 export interface IAzureCloudStorageOptions {
-    projectName: string;
     accountName: string;
     containerName: string;
     createContainer: boolean;
@@ -192,13 +191,12 @@ export class AzureBlobStorage implements IStorageProvider {
      * @param containerName - Container from which to retrieve assets. Defaults to
      * container specified in Azure Cloud Storage options
      */
-    public async getAssets(containerName?: string): Promise<IAsset[]> {
-        containerName = (containerName) ? containerName : this.options.containerName;
-        const files = await this.listFiles(containerName);
+    public async getAssets(projectName: string): Promise<IAsset[]> {
+        const files = await this.listFiles(this.options.containerName);
         const result: IAsset[] = [];
         for (const file of files) {
             const url = this.getUrl(file);
-            const asset = AssetService.createAssetFromFilePath(url, this.options.projectName, this.getFileName(url));
+            const asset = AssetService.createAssetFromFilePath(url, projectName, this.getFileName(url));
             if (asset.type !== AssetType.Unknown) {
                 result.push(asset);
             }

--- a/src/providers/storage/azureBlobStorage.ts
+++ b/src/providers/storage/azureBlobStorage.ts
@@ -191,13 +191,13 @@ export class AzureBlobStorage implements IStorageProvider {
      * @param containerName - Container from which to retrieve assets. Defaults to
      * container specified in Azure Cloud Storage options
      */
-    public async getAssets(containerName?: string): Promise<IAsset[]> {
+    public async getAssets(containerName?: string, projectName?: string): Promise<IAsset[]> {
         containerName = (containerName) ? containerName : this.options.containerName;
         const files = await this.listFiles(containerName);
         const result: IAsset[] = [];
         for (const file of files) {
             const url = this.getUrl(file);
-            const asset = AssetService.createAssetFromFilePath(url, this.getFileName(url));
+            const asset = AssetService.createAssetFromFilePath(url, projectName, this.getFileName(url));
             if (asset.type !== AssetType.Unknown) {
                 result.push(asset);
             }

--- a/src/providers/storage/bingImageSearch.test.ts
+++ b/src/providers/storage/bingImageSearch.test.ts
@@ -5,12 +5,12 @@ import MD5 from "md5.js";
 
 describe("Bing Image Search", () => {
     const options: IBingImageSearchOptions = {
-        projectName: "myproject",
         apiKey: "ABC123",
         query: "Waterfalls",
         aspectRatio: BingImageSearchAspectRatio.All,
     };
     const provider = new BingImageSearch(options);
+    const projectName = "my project";
 
     const assets = [
         { contentUrl: "http://images.com/image1.jpg" },
@@ -37,7 +37,7 @@ describe("Bing Image Search", () => {
             },
         };
 
-        await provider.getAssets();
+        await provider.getAssets(projectName);
         expect(axios.get).toBeCalledWith(expectedUrl, expectedHeaders);
     });
 
@@ -52,7 +52,7 @@ describe("Bing Image Search", () => {
             size: null,
         };
 
-        const assets = await provider.getAssets();
+        const assets = await provider.getAssets(projectName);
         expect(assets.length).toEqual(assets.length);
         expect(assets[0]).toEqual(expectedAsset);
     });

--- a/src/providers/storage/bingImageSearch.test.ts
+++ b/src/providers/storage/bingImageSearch.test.ts
@@ -5,6 +5,7 @@ import MD5 from "md5.js";
 
 describe("Bing Image Search", () => {
     const options: IBingImageSearchOptions = {
+        projectName: "myproject",
         apiKey: "ABC123",
         query: "Waterfalls",
         aspectRatio: BingImageSearchAspectRatio.All,

--- a/src/providers/storage/bingImageSearch.test.ts
+++ b/src/providers/storage/bingImageSearch.test.ts
@@ -42,8 +42,12 @@ describe("Bing Image Search", () => {
     });
 
     it("returns parsed image assets", async () => {
+        const hashTarget = JSON.stringify({
+            projectName,
+            filePath: "http://images.com/image1.jpg",
+        });
         const expectedAsset: IAsset = {
-            id: new MD5().update("http://images.com/image1.jpg").digest("hex"),
+            id: new MD5().update(hashTarget).digest("hex"),
             projectName,
             format: "jpg",
             name: "image1.jpg",

--- a/src/providers/storage/bingImageSearch.test.ts
+++ b/src/providers/storage/bingImageSearch.test.ts
@@ -44,6 +44,7 @@ describe("Bing Image Search", () => {
     it("returns parsed image assets", async () => {
         const expectedAsset: IAsset = {
             id: new MD5().update("http://images.com/image1.jpg").digest("hex"),
+            projectName,
             format: "jpg",
             name: "image1.jpg",
             path: "http://images.com/image1.jpg",

--- a/src/providers/storage/bingImageSearch.ts
+++ b/src/providers/storage/bingImageSearch.ts
@@ -12,6 +12,7 @@ import { createQueryString } from "../../common/utils";
  * @member aspectRatio - Aspect Ratio for desired images
  */
 export interface IBingImageSearchOptions {
+    projectName: string;
     apiKey: string;
     query: string;
     aspectRatio: BingImageSearchAspectRatio;
@@ -40,7 +41,7 @@ export class BingImageSearch implements IAssetProvider {
     /**
      * Retrieves assets from Bing Image Search based on options provided
      */
-    public async getAssets(projectName: string): Promise<IAsset[]> {
+    public async getAssets(): Promise<IAsset[]> {
         const query = {
             q: this.options.query,
             aspect: this.options.aspectRatio,
@@ -58,7 +59,7 @@ export class BingImageSearch implements IAssetProvider {
         const items = response.data.value.map((item) => item.contentUrl);
 
         return items
-            .map((filePath) => AssetService.createAssetFromFilePath(filePath, projectName))
+            .map((filePath) => AssetService.createAssetFromFilePath(filePath, this.options.projectName))
             .filter((asset) => asset.type !== AssetType.Unknown);
     }
 }

--- a/src/providers/storage/bingImageSearch.ts
+++ b/src/providers/storage/bingImageSearch.ts
@@ -40,7 +40,7 @@ export class BingImageSearch implements IAssetProvider {
     /**
      * Retrieves assets from Bing Image Search based on options provided
      */
-    public async getAssets(): Promise<IAsset[]> {
+    public async getAssets(projectName: string): Promise<IAsset[]> {
         const query = {
             q: this.options.query,
             aspect: this.options.aspectRatio,
@@ -58,7 +58,7 @@ export class BingImageSearch implements IAssetProvider {
         const items = response.data.value.map((item) => item.contentUrl);
 
         return items
-            .map((filePath) => AssetService.createAssetFromFilePath(filePath))
+            .map((filePath) => AssetService.createAssetFromFilePath(filePath, projectName))
             .filter((asset) => asset.type !== AssetType.Unknown);
     }
 }

--- a/src/providers/storage/bingImageSearch.ts
+++ b/src/providers/storage/bingImageSearch.ts
@@ -12,7 +12,6 @@ import { createQueryString } from "../../common/utils";
  * @member aspectRatio - Aspect Ratio for desired images
  */
 export interface IBingImageSearchOptions {
-    projectName: string;
     apiKey: string;
     query: string;
     aspectRatio: BingImageSearchAspectRatio;
@@ -41,7 +40,7 @@ export class BingImageSearch implements IAssetProvider {
     /**
      * Retrieves assets from Bing Image Search based on options provided
      */
-    public async getAssets(): Promise<IAsset[]> {
+    public async getAssets(projectName: string): Promise<IAsset[]> {
         const query = {
             q: this.options.query,
             aspect: this.options.aspectRatio,
@@ -59,7 +58,7 @@ export class BingImageSearch implements IAssetProvider {
         const items = response.data.value.map((item) => item.contentUrl);
 
         return items
-            .map((filePath) => AssetService.createAssetFromFilePath(filePath, this.options.projectName))
+            .map((filePath) => AssetService.createAssetFromFilePath(filePath, projectName))
             .filter((asset) => asset.type !== AssetType.Unknown);
     }
 }

--- a/src/providers/storage/localFileSystemProxy.ts
+++ b/src/providers/storage/localFileSystemProxy.ts
@@ -125,8 +125,8 @@ export class LocalFileSystemProxy implements IStorageProvider, IAssetProvider {
      * Retrieve assets from directory
      * @param folderName - Directory containing assets
      */
-    public getAssets(folderName?: string): Promise<IAsset[]> {
-        const folderPath = [this.options.folderPath, folderName].join("/");
-        return IpcRendererProxy.send(`${PROXY_NAME}:getAssets`, [folderPath]);
+    public getAssets(projectName: string): Promise<IAsset[]> {
+        const folderPath = [this.options.folderPath].join("/");
+        return IpcRendererProxy.send(`${PROXY_NAME}:getAssets`, [this.options.folderPath, projectName]);
     }
 }

--- a/src/providers/storage/localFileSystemProxy.ts
+++ b/src/providers/storage/localFileSystemProxy.ts
@@ -126,7 +126,6 @@ export class LocalFileSystemProxy implements IStorageProvider, IAssetProvider {
      * @param folderName - Directory containing assets
      */
     public getAssets(projectName: string): Promise<IAsset[]> {
-        const folderPath = [this.options.folderPath].join("/");
         return IpcRendererProxy.send(`${PROXY_NAME}:getAssets`, [this.options.folderPath, projectName]);
     }
 }

--- a/src/react/components/common/assetPreview/assetPreview.test.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.test.tsx
@@ -18,6 +18,7 @@ describe("Asset Preview Component", () => {
     const onChildAssetSelectedHandler = jest.fn();
     const onAssetChangedHandler = jest.fn();
     const onBeforeAssetChangedHandler = jest.fn(() => true);
+    const projectName = "my project";
 
     const defaultProps: IAssetPreviewProps = {
         asset: {
@@ -63,7 +64,7 @@ describe("Asset Preview Component", () => {
     it("renders a video asset when asset type is video", () => {
         const props: IAssetPreviewProps = {
             ...defaultProps,
-            asset: MockFactory.createVideoTestAsset("test-video-asset"),
+            asset: MockFactory.createVideoTestAsset("test-video-asset", projectName),
         };
         wrapper = createComponent(props);
         const videoProps = wrapper.find(VideoAsset).props();
@@ -140,7 +141,7 @@ describe("Asset Preview Component", () => {
     it("raises asset error handler when a video asset fails to load successfully", () => {
         const props: IAssetPreviewProps = {
             ...defaultProps,
-            asset: MockFactory.createVideoTestAsset("test-video-asset"),
+            asset: MockFactory.createVideoTestAsset("test-video-asset", projectName),
         };
         wrapper = createComponent(props);
         const errorEvent = new Event("error");
@@ -154,7 +155,7 @@ describe("Asset Preview Component", () => {
     it("raises asset loaded handler when image asset loading is complete", () => {
         const props: IAssetPreviewProps = {
             ...defaultProps,
-            asset: MockFactory.createVideoTestAsset("test-video-asset"),
+            asset: MockFactory.createVideoTestAsset("test-video-asset", projectName),
         };
         wrapper = createComponent(props);
         wrapper.find(VideoAsset).props().onLoaded(document.createElement("video"));
@@ -182,17 +183,17 @@ describe("Asset Preview Component", () => {
     it("raises child asset selected handler when a child asset is selected", () => {
         const props: IAssetPreviewProps = {
             ...defaultProps,
-            asset: MockFactory.createVideoTestAsset("test-video-asset"),
+            asset: MockFactory.createVideoTestAsset("test-video-asset", projectName),
         };
         wrapper = createComponent(props);
-        const childAsset = MockFactory.createChildVideoAsset(props.asset, 10);
+        const childAsset = MockFactory.createChildVideoAsset(props.asset, 10, projectName);
         wrapper.find(VideoAsset).props().onChildAssetSelected(childAsset);
 
         expect(onChildAssetSelectedHandler).toBeCalledWith(childAsset);
     });
 
     it("raises onBeforeAssetChanged during asset transitions", () => {
-        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset");
+        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset", projectName);
         const props: IAssetPreviewProps = {
             ...defaultProps,
             asset: videoAsset,
@@ -204,8 +205,8 @@ describe("Asset Preview Component", () => {
     });
 
     it("blocks onChildAssetSelected", () => {
-        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset");
-        const childAsset = MockFactory.createChildVideoAsset(videoAsset, 2);
+        const videoAsset = MockFactory.createVideoTestAsset("test-video-asset", projectName);
+        const childAsset = MockFactory.createChildVideoAsset(videoAsset, 2, projectName);
         onBeforeAssetChangedHandler.mockImplementationOnce(() => false);
 
         const props: IAssetPreviewProps = {

--- a/src/react/components/common/assetPreview/videoAsset.test.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.test.tsx
@@ -22,8 +22,9 @@ describe("Video Asset Component", () => {
     const onDeactivatedHandler = jest.fn();
     const onChildSelectedHandler = jest.fn();
     const onBeforeAssetChangedHandler = jest.fn(() => true);
+    const projectName = "my project";
     const defaultProps: IVideoAssetProps = {
-        asset: MockFactory.createVideoTestAsset("test-video"),
+        asset: MockFactory.createVideoTestAsset("test-video", projectName),
         autoPlay: true,
         controlsEnabled: true,
         timestamp: 0,
@@ -78,7 +79,7 @@ describe("Video Asset Component", () => {
         wrapper = createComponent();
         mockLoaded();
 
-        const newAsset = MockFactory.createVideoTestAsset("new-video-asset");
+        const newAsset = MockFactory.createVideoTestAsset("new-video-asset", projectName);
         wrapper.setProps({ asset: newAsset });
         expect(wrapper.state().loaded).toBe(false);
     });
@@ -91,7 +92,7 @@ describe("Video Asset Component", () => {
         wrapper = createComponent(testProps);
         mockLoaded();
 
-        const newAsset = MockFactory.createVideoTestAsset("new-video-asset");
+        const newAsset = MockFactory.createVideoTestAsset("new-video-asset", projectName);
         wrapper.setProps({ asset: newAsset });
         expect(videoPlayerMock.prototype.subscribeToStateChange).not.toBeCalled();
     });

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -237,7 +237,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
             // Video is paused, make sure we are on a key frame, and if we are not, seek to that
             // before raising the child selected event
             if (this.isValidKeyFrame()) {
-                this.raiseChildAssetSelected(state, );
+                this.raiseChildAssetSelected(state );
                 this.raiseDeactivated();
             }
         } else if (!state.paused && state.paused !== prev.paused) {

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -265,11 +265,11 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     /**
      * Raises the "childAssetSelected" event if available
      */
-    private raiseChildAssetSelected = (state: Readonly<IVideoPlayerState>) => {
+    private raiseChildAssetSelected = (state: Readonly<IVideoPlayerState>, projectName: string) => {
         if (this.props.onChildAssetSelected) {
             const rootAsset = this.props.asset.parent || this.props.asset;
             const childPath = `${rootAsset.path}#t=${state.currentTime}`;
-            const childAsset = AssetService.createAssetFromFilePath(childPath);
+            const childAsset = AssetService.createAssetFromFilePath(childPath, projectName);
             childAsset.state = AssetState.NotVisited;
             childAsset.type = AssetType.VideoFrame;
             childAsset.parent = rootAsset;

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -237,7 +237,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
             // Video is paused, make sure we are on a key frame, and if we are not, seek to that
             // before raising the child selected event
             if (this.isValidKeyFrame()) {
-                this.raiseChildAssetSelected(state);
+                this.raiseChildAssetSelected(state, );
                 this.raiseDeactivated();
             }
         } else if (!state.paused && state.paused !== prev.paused) {
@@ -265,11 +265,11 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     /**
      * Raises the "childAssetSelected" event if available
      */
-    private raiseChildAssetSelected = (state: Readonly<IVideoPlayerState>, projectName: string) => {
+    private raiseChildAssetSelected = (state: Readonly<IVideoPlayerState>) => {
         if (this.props.onChildAssetSelected) {
             const rootAsset = this.props.asset.parent || this.props.asset;
             const childPath = `${rootAsset.path}#t=${state.currentTime}`;
-            const childAsset = AssetService.createAssetFromFilePath(childPath, projectName);
+            const childAsset = AssetService.createAssetFromFilePath(childPath, rootAsset.projectName);
             childAsset.state = AssetState.NotVisited;
             childAsset.type = AssetType.VideoFrame;
             childAsset.parent = rootAsset;

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -393,7 +393,7 @@ describe("Editor Page Component", () => {
 
         beforeEach(async () => {
             const testProject = MockFactory.createTestProject("TestProject");
-            videoAsset = MockFactory.createVideoTestAsset("TestVideo");
+            videoAsset = MockFactory.createVideoTestAsset("TestVideo", testProject.name);
             videoFrames = MockFactory.createChildVideoAssets(videoAsset);
             const projectAssets = [videoAsset].concat(videoFrames);
             testProject.assets = _.keyBy(projectAssets, (asset) => asset.id);

--- a/src/react/components/pages/projectSettings/projectMetrics.tsx
+++ b/src/react/components/pages/projectSettings/projectMetrics.tsx
@@ -238,8 +238,9 @@ export default class ProjectMetrics extends React.Component<IProjectMetricsProps
     }
 
     private async getAssetsAndMetadata() {
-        const assetService = new AssetService(this.props.project);
-        const sourceAssets = await assetService.getAssets();
+        const {project} = this.props;
+        const assetService = new AssetService(project);
+        const sourceAssets = await assetService.getAssets(project.name);
 
         const assetsMap = this.props.project.assets;
         const assets = _.values(assetsMap);

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -131,7 +131,7 @@ export function closeProject(): (dispatch: Dispatch) => void {
 export function loadAssets(project: IProject): (dispatch: Dispatch) => Promise<IAsset[]> {
     return async (dispatch: Dispatch) => {
         const assetService = new AssetService(project);
-        const assets = await assetService.getAssets();
+        const assets = await assetService.getAssets(project.name);
         dispatch(loadProjectAssetsAction(assets));
 
         return assets;

--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -12,9 +12,11 @@ import registerMixins from "../registerMixins";
 
 describe("Asset Service", () => {
     describe("Static Methods", () => {
+        const projectName = "test";
+
         it("creates an asset from a file path", () => {
             const path = "C:\\dir1\\dir2\\asset1.jpg";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
 
             expect(asset).not.toBeNull();
             expect(asset.id).toEqual(expect.any(String));
@@ -26,7 +28,7 @@ describe("Asset Service", () => {
 
         it("creates an asset from an encoded file", () => {
             const path = "C:\\dir1\\dir2\\asset%201.jpg";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
 
             expect(asset).not.toBeNull();
             expect(asset.id).toEqual(expect.any(String));
@@ -38,7 +40,7 @@ describe("Asset Service", () => {
 
         it("creates an asset from a http source", () => {
             const path = "http://my.server.com/asset1.jpg";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
 
             expect(asset).not.toBeNull();
             expect(asset.id).toEqual(expect.any(String));
@@ -50,43 +52,43 @@ describe("Asset Service", () => {
 
         it("detects an image asset by common file extension", () => {
             const path = "C:\\dir1\\dir2\\asset1.png";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Image);
         });
 
         it("detects a video asset by common file extension", () => {
             const path = "C:\\dir1\\dir2\\asset1.mp4";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Video);
         });
 
         it("detects a video asset by common file extension", () => {
             const path = "file:C:/dir1/dir2/asset1.mp4#t=5";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Video);
         });
 
         it("detects a tfrecord asset by common file extension", () => {
             const path = "C:\\dir1\\dir2\\asset1.tfrecord";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.TFRecord);
         });
 
         it("detects an asset as unkonwn if it doesn't match well known file extensions", () => {
             const path = "C:\\dir1\\dir2\\asset1.docx";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Unknown);
         });
 
         it("detects an asset in case asset name contains other file extension in the middle", () => {
             const path = "C:\\dir1\\dir2\\asset1.docx.jpg";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Image);
         });
 
         it("detects an asset in case asset name contains other file extension in the middle", () => {
             const path = "C:\\dir1\\dir2\\asset1.jpg.docx";
-            const asset = AssetService.createAssetFromFilePath(path);
+            const asset = AssetService.createAssetFromFilePath(path, projectName);
             expect(asset.type).toEqual(AssetType.Unknown);
         });
     });

--- a/src/services/assetService.test.ts
+++ b/src/services/assetService.test.ts
@@ -11,8 +11,9 @@ import _ from "lodash";
 import registerMixins from "../registerMixins";
 
 describe("Asset Service", () => {
+    const projectName = "test";
+
     describe("Static Methods", () => {
-        const projectName = "test";
 
         it("creates an asset from a file path", () => {
             const path = "C:\\dir1\\dir2\\asset1.jpg";
@@ -99,6 +100,7 @@ describe("Asset Service", () => {
         let assetService: AssetService = null;
         let assetProviderMock: IAssetProvider = null;
         let storageProviderMock: any = null;
+        const projectName = "my project";
 
         beforeEach(() => {
             assetProviderMock = {
@@ -189,7 +191,7 @@ describe("Asset Service", () => {
             const testAsset = MockFactory.createTestAsset(" 11");
             testAssets.push(testAsset);
 
-            const result = await assetService.getAssets();
+            const result = await assetService.getAssets(projectName);
             const expected = encodeFileURI("C:\\Desktop\\asset 11.jpg");
 
             expect(result[10].path).toEqual(expected);
@@ -199,7 +201,7 @@ describe("Asset Service", () => {
             const testAsset = MockFactory.createTestAsset("#test?");
             testAssets.push(testAsset);
 
-            const result = await assetService.getAssets();
+            const result = await assetService.getAssets(projectName);
             const expected = encodeFileURI("C:\\Desktop\\asset#test?.jpg");
 
             expect(result[11].path).toEqual(expected);
@@ -209,7 +211,7 @@ describe("Asset Service", () => {
             const testAsset = MockFactory.createTestAsset("~!@#$&*()=:,;?+'");
             testAssets.push(testAsset);
 
-            const result = await assetService.getAssets();
+            const result = await assetService.getAssets(projectName);
             const expected = encodeFileURI("C:\\Desktop\\asset~!@#$&*()=:,;?+'.jpg");
 
             expect(result[12].path).toEqual(expected);
@@ -248,7 +250,7 @@ describe("Asset Service", () => {
         });
 
         it("Check file protocol", async () => {
-            const assets = await assetService.getAssets();
+            const assets = await assetService.getAssets(projectName);
 
             expect(assets.length).toEqual(2);
             expect(assets[0].path).toEqual("file:C:/Desktop/asset0.jpg");

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -40,10 +40,10 @@ export class AssetService {
             filePath = encodeFileURI(filePath, true);
         }
 
-        const hashTarget = projectName ? JSON.stringify({
+        const hashTarget = JSON.stringify({
             projectName,
             filePath
-        }) : filePath
+        });
 
         const md5Hash = new MD5().update(hashTarget).digest("hex");
         const pathParts = filePath.split(/[\\\/]/);

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -60,6 +60,7 @@ export class AssetService {
 
         return {
             id: md5Hash,
+            projectName,
             format: assetFormat,
             state: AssetState.NotVisited,
             type: assetType,
@@ -135,8 +136,8 @@ export class AssetService {
     /**
      * Get assets from provider
      */
-    public async getAssets(): Promise<IAsset[]> {
-        return await this.assetProvider.getAssets();
+    public async getAssets(projectName: string): Promise<IAsset[]> {
+        return await this.assetProvider.getAssets(projectName);
     }
 
     /**

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -42,7 +42,7 @@ export class AssetService {
 
         const hashTarget = JSON.stringify({
             projectName,
-            filePath
+            filePath,
         });
 
         const md5Hash = new MD5().update(hashTarget).digest("hex");

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -26,7 +26,7 @@ export class AssetService {
      * @param filePath - filepath of asset
      * @param fileName - name of asset
      */
-    public static createAssetFromFilePath(filePath: string, fileName?: string): IAsset {
+    public static createAssetFromFilePath(filePath: string, fileName?: string, projectName?: string): IAsset {
         Guard.empty(filePath);
 
         const normalizedPath = filePath.toLowerCase();
@@ -40,7 +40,12 @@ export class AssetService {
             filePath = encodeFileURI(filePath, true);
         }
 
-        const md5Hash = new MD5().update(filePath).digest("hex");
+        const hashTarget = projectName ? JSON.stringify({
+            projectName,
+            filePath
+        }) : filePath
+
+        const md5Hash = new MD5().update(hashTarget).digest("hex");
         const pathParts = filePath.split(/[\\\/]/);
         // Example filename: video.mp4#t=5
         // fileNameParts[0] = "video"

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -26,7 +26,7 @@ export class AssetService {
      * @param filePath - filepath of asset
      * @param fileName - name of asset
      */
-    public static createAssetFromFilePath(filePath: string, fileName?: string, projectName?: string): IAsset {
+    public static createAssetFromFilePath(filePath: string, projectName: string, fileName?: string): IAsset {
         Guard.empty(filePath);
 
         const normalizedPath = filePath.toLowerCase();

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -163,7 +163,8 @@ export default class ImportService implements IImportService {
      */
     private async createParentVideoAsset(v1Project: IFileInfo): Promise<IAsset> {
         const filePath = v1Project.file.path.replace(/\.[^/.]+$/, "");
-        const parentAsset = AssetService.createAssetFromFilePath(filePath, v1Project.file.name, filePath.replace(/^.*[\\\/]/, ""));
+        const parentAsset = AssetService.createAssetFromFilePath(
+            filePath, v1Project.file.name, filePath.replace(/^.*[\\\/]/, ""));
         const assetProps = await HtmlFileReader.readAssetAttributes(parentAsset);
 
         parentAsset.size = { height: assetProps.height, width: assetProps.width };

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -112,7 +112,7 @@ export default class ImportService implements IImportService {
 
         return await frames.mapAsync(async (frame) => {
             const filePath = `${projectPath}/${frame.name}`;
-            const asset = AssetService.createAssetFromFilePath(filePath);
+            const asset = AssetService.createAssetFromFilePath(filePath, v1Project.file.name);
             const assetState = this.getAssetState(frame);
 
             return await this.createAssetMetadata(asset, assetState, frame.regions);
@@ -131,7 +131,7 @@ export default class ImportService implements IImportService {
         const videoFrameAssets = await frames.mapAsync(async (frame) => {
             const frameInt = Number(frame.name);
             const timestamp = (frameInt - 1) / Number(originalProject.framerate);
-            const asset = this.createVideoFrameAsset(parentVideoAsset, timestamp);
+            const asset = this.createVideoFrameAsset(parentVideoAsset, timestamp, v1Project.file.name);
             const assetState = this.getAssetState(frame);
 
             return await this.createAssetMetadata(asset, assetState, frame.regions, parentVideoAsset);
@@ -163,7 +163,7 @@ export default class ImportService implements IImportService {
      */
     private async createParentVideoAsset(v1Project: IFileInfo): Promise<IAsset> {
         const filePath = v1Project.file.path.replace(/\.[^/.]+$/, "");
-        const parentAsset = AssetService.createAssetFromFilePath(filePath, filePath.replace(/^.*[\\\/]/, ""));
+        const parentAsset = AssetService.createAssetFromFilePath(filePath, v1Project.file.name, filePath.replace(/^.*[\\\/]/, ""));
         const assetProps = await HtmlFileReader.readAssetAttributes(parentAsset);
 
         parentAsset.size = { height: assetProps.height, width: assetProps.width };
@@ -243,9 +243,9 @@ export default class ImportService implements IImportService {
      * @param parent The parent video asset
      * @param timestamp The timestamp for the child video frame
      */
-    private createVideoFrameAsset(parent: IAsset, timestamp: number): IAsset {
+    private createVideoFrameAsset(parent: IAsset, timestamp: number, projectName: string): IAsset {
         return {
-            ...AssetService.createAssetFromFilePath(`${parent.path}#t=${timestamp}`),
+            ...AssetService.createAssetFromFilePath(`${parent.path}#t=${timestamp}`, projectName),
             timestamp,
             parent,
             type: AssetType.VideoFrame,


### PR DESCRIPTION
- Hashes asset file IDs with project name to allow for multiple projects using the same assets
- Updates `IAsset` to contain `projectName` property
- Updates assetProvider to use `projectName` in the `getAssets` call

Resolves [[AB#18063](https://dev.azure.com/dwrdev/e2e1d5cd-80d1-4aa1-9b7d-b19c4bcaa288/_workitems/edit/18063)]