### PR TITLE
fix: Update export options for pascalVOC rename

### DIFF
--- a/src/services/projectService.test.ts
+++ b/src/services/projectService.test.ts
@@ -12,6 +12,7 @@ import { generateKey } from "../common/crypto";
 import { encryptProject, decryptProject } from "../common/utils";
 import { ExportAssetState } from "../providers/export/exportProvider";
 import { IVottJsonExportProviderOptions } from "../providers/export/vottJson";
+import { IPascalVOCExportProviderOptions } from "../providers/export/pascalVOC";
 
 describe("Project Service", () => {
     let projectSerivce: IProjectService = null;
@@ -200,5 +201,24 @@ describe("Project Service", () => {
 
         await projectSerivce.delete(testProject);
         expect(storageProviderMock.deleteFile.mock.calls).toHaveLength(assets.length + 1);
+    });
+
+    it("Updates export settings to v2.1 supported values", async () => {
+        testProject = MockFactory.createTestProject("TestProject");
+        testProject.version = "2.0.0";
+        testProject.exportFormat = {
+            providerType: "tensorFlowPascalVOC",
+            providerOptions: {
+                assetState: ExportAssetState.All,
+                exportUnassigned: true,
+                testTrainSplit: 80,
+            } as IPascalVOCExportProviderOptions,
+        };
+
+        const encryptedProject = encryptProject(testProject, securityToken);
+        const decryptedProject = await projectSerivce.load(encryptedProject, securityToken);
+
+        expect(decryptedProject.exportFormat.providerType).toEqual("pascalVOC");
+        expect(decryptedProject.exportFormat.providerOptions).toEqual(testProject.exportFormat.providerOptions);
     });
 });

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -70,6 +70,8 @@ export default class ProjectService implements IProjectService {
                 loadedProject.exportFormat = defaultExportOptions;
             }
 
+            this.ensureBackwardsCompatibility(loadedProject);
+
             return Promise.resolve({ ...loadedProject });
         } catch (e) {
             const error = new AppError(ErrorCode.ProjectInvalidSecurityToken, "Error decrypting project settings");
@@ -162,5 +164,18 @@ export default class ProjectService implements IProjectService {
         }
 
         project.exportFormat.providerOptions = await exportProvider.save(project.exportFormat);
+    }
+
+    /**
+     * Ensures backwards compatibility with project
+     * @param project The project to update
+     */
+    private ensureBackwardsCompatibility(project: IProject) {
+        if (project.version === "2.0.0") {
+            // Required for backwards compatibility with v2.0.0 release
+            if (project.exportFormat.providerType === "tensorFlowPascalVOC") {
+                project.exportFormat.providerType = "pascalVOC";
+            }
+        }
     }
 }


### PR DESCRIPTION
When loading a v2.0.0 project that was configured to use `tensorflowPascalVOC` export provider it fails on project load and get stuck in an infinite loop

**Fix**
Adds a check during project load to update the export options if project was using previous pascalVOC name. 