### PR TITLE
Update active learning classes.json processor

### DIFF
--- a/src/providers/activeLearning/electronProxyHandler.ts
+++ b/src/providers/activeLearning/electronProxyHandler.ts
@@ -28,7 +28,11 @@ export class ElectronProxyHandler implements tfc.io.IOHandler {
 
     public async loadClasses(): Promise<JSON> {
         const json = await this.provider.readText("/classes.json");
-        return json ? JSON.parse(json) : null;
+        // Assign each element to it's respective index. Indexing starts from
+        // 1 in classes.json, so subtract 1 from each index during assignment.
+        return json ? JSON.parse(json).reduce((acc, curr) => {
+            acc[curr.id - 1] = curr; return acc;
+        }, []) : null;
     }
 
     private async loadWeights(weightsManifest: tfc.io.WeightsManifestConfig)

--- a/src/providers/activeLearning/objectDetection.ts
+++ b/src/providers/activeLearning/objectDetection.ts
@@ -222,7 +222,7 @@ export class ObjectDetection {
 
     private getClass(index: number, indexes: Float32Array, classes: number[]): string {
         if (this.jsonClasses && index < indexes.length && indexes[index] < classes.length) {
-            const classId = classes[indexes[index]] - 1;
+            const classId = classes[indexes[index]];
             const classObject = this.jsonClasses[classId];
 
             return classObject ? classObject.displayName : strings.tags.warnings.unknownTagName;


### PR DESCRIPTION
Previously, the code that loads in the classes.json file did not account for the missing classes in COCO.  This fixes associated indexing issues so that active learning with the default cocossd model works out of the box on the coco dataset.