### PR TITLE
fix: test asset distribution to include all tags on test/train split

### DIFF
--- a/src/providers/export/cntk.ts
+++ b/src/providers/export/cntk.ts
@@ -3,7 +3,7 @@ import { ExportProvider, IExportResults } from "./exportProvider";
 import { IAssetMetadata, IExportProviderOptions, IProject } from "../../models/applicationState";
 import HtmlFileReader from "../../common/htmlFileReader";
 import Guard from "../../common/guard";
-import {splitTestAsset} from "./testAssetsSplitHelper";
+import { splitTestAsset } from "./testAssetsSplitHelper";
 
 enum ExportSplit {
     Test,

--- a/src/providers/export/pascalVOC.ts
+++ b/src/providers/export/pascalVOC.ts
@@ -6,6 +6,7 @@ import HtmlFileReader from "../../common/htmlFileReader";
 import { itemTemplate, annotationTemplate, objectTemplate } from "./pascalVOC/pascalVOCTemplates";
 import { interpolate } from "../../common/strings";
 import os from "os";
+import { splitTestAsset } from "./testAssetsSplitHelper";
 
 interface IObjectInfo {
     name: string;
@@ -254,25 +255,8 @@ export class PascalVOCExportProvider extends ExportProvider<IPascalVOCExportProv
         });
 
         if (testSplit > 0 && testSplit <= 1) {
-            const testAssets: string[] = [];
-            const tagsAssetDict: { [index: string]: { assetList: Set<string> } } = {};
             const tags = this.project.tags;
-            tags.forEach((tag) => tagsAssetDict[tag.name] = { assetList: new Set() });
-            allAssets.forEach((assetMetadata) => {
-                assetMetadata.regions.forEach((region) => {
-                    region.tags.forEach((tagName) => {
-                        if (tagsAssetDict[tagName]) {
-                            tagsAssetDict[tagName].assetList.add(assetMetadata.asset.name);
-                        }
-                    });
-                });
-            });
-
-            for (const tagKey of Object.keys(tagsAssetDict)) {
-                const assetList = tagsAssetDict[tagKey].assetList;
-                const testCount = Math.ceil(assetList.size * testSplit);
-                testAssets.push(...Array.from(assetList).slice(0, testCount));
-            }
+            const testAssets: string[] = splitTestAsset(allAssets, tags, testSplit);
 
             await tags.forEachAsync(async (tag) => {
                 const tagInstances = tagUsage.get(tag.name) || 0;

--- a/src/providers/export/pascalVOC.ts
+++ b/src/providers/export/pascalVOC.ts
@@ -253,40 +253,75 @@ export class PascalVOCExportProvider extends ExportProvider<IPascalVOCExportProv
             }
         });
 
-        // Save ImageSets
-        await tags.forEachAsync(async (tag) => {
-            const tagInstances = tagUsage.get(tag.name) || 0;
-            if (!exportUnassignedTags && tagInstances === 0) {
-                return;
-            }
-
-            const assetList = [];
-            assetUsage.forEach((tags, assetName) => {
-                if (tags.has(tag.name)) {
-                    assetList.push(`${assetName} 1`);
-                } else {
-                    assetList.push(`${assetName} -1`);
-                }
+        if (testSplit > 0 && testSplit <= 1) {
+            const testAssets: string[] = [];
+            const tagsAssetDict: { [index: string]: { assetList: Set<string> } } = {};
+            const tags = this.project.tags;
+            tags.forEach((tag) => tagsAssetDict[tag.name] = { assetList: new Set() });
+            allAssets.forEach((assetMetadata) => {
+                assetMetadata.regions.forEach((region) => {
+                    region.tags.forEach((tagName) => {
+                        if (tagsAssetDict[tagName]) {
+                            tagsAssetDict[tagName].assetList.add(assetMetadata.asset.name);
+                        }
+                    });
+                });
             });
 
-            if (testSplit > 0 && testSplit <= 1) {
-                // Split in Test and Train sets
-                const totalAssets = assetUsage.size;
-                const testCount = Math.ceil(totalAssets * testSplit);
+            for (const tagKey of Object.keys(tagsAssetDict)) {
+                const assetList = tagsAssetDict[tagKey].assetList;
+                const testCount = Math.ceil(assetList.size * testSplit);
+                testAssets.push(...Array.from(assetList).slice(0, testCount));
+            }
 
-                const testArray = assetList.slice(0, testCount);
-                const trainArray = assetList.slice(testCount, totalAssets);
+            await tags.forEachAsync(async (tag) => {
+                const tagInstances = tagUsage.get(tag.name) || 0;
+                if (!exportUnassignedTags && tagInstances === 0) {
+                    return;
+                }
+                const testArray = [];
+                const trainArray = [];
+                assetUsage.forEach((tags, assetName) => {
+                    let assetString = "";
+                    if (tags.has(tag.name)) {
+                        assetString = `${assetName} 1`;
+                    } else {
+                        assetString = `${assetName} -1`;
+                    }
+                    if (testAssets.find((am) => am === assetName)) {
+                        testArray.push(assetString);
+                    } else {
+                        trainArray.push(assetString);
+                    }
+                });
 
                 const testImageSetFileName = `${imageSetsMainFolderName}/${tag.name}_val.txt`;
                 await this.storageProvider.writeText(testImageSetFileName, testArray.join(os.EOL));
 
                 const trainImageSetFileName = `${imageSetsMainFolderName}/${tag.name}_train.txt`;
                 await this.storageProvider.writeText(trainImageSetFileName, trainArray.join(os.EOL));
+            });
+        } else {
 
-            } else {
+            // Save ImageSets
+            await tags.forEachAsync(async (tag) => {
+                const tagInstances = tagUsage.get(tag.name) || 0;
+                if (!exportUnassignedTags && tagInstances === 0) {
+                    return;
+                }
+
+                const assetList = [];
+                assetUsage.forEach((tags, assetName) => {
+                    if (tags.has(tag.name)) {
+                        assetList.push(`${assetName} 1`);
+                    } else {
+                        assetList.push(`${assetName} -1`);
+                    }
+                });
+
                 const imageSetFileName = `${imageSetsMainFolderName}/${tag.name}.txt`;
                 await this.storageProvider.writeText(imageSetFileName, assetList.join(os.EOL));
-            }
-        });
+            });
+        }
     }
 }

--- a/src/providers/export/testAssetsSplitHelper.test.ts
+++ b/src/providers/export/testAssetsSplitHelper.test.ts
@@ -1,0 +1,61 @@
+import _ from "lodash";
+import {
+    IAssetMetadata, AssetState, IRegion,
+    RegionType, IPoint, IExportProviderOptions,
+} from "../../models/applicationState";
+import MockFactory from "../../common/mockFactory";
+import { splitTestAsset } from "./testAssetsSplitHelper";
+import { appInfo } from "../../common/appInfo";
+
+describe("splitTestAsset Helper tests", () => {
+
+    describe("Test Train Splits", () => {
+        async function testTestTrainSplit(testTrainSplit: number): Promise<void> {
+            const assetArray = MockFactory.createTestAssets(13, 0);
+            const tags = MockFactory.createTestTags(2);
+            assetArray.forEach((asset) => asset.state = AssetState.Tagged);
+
+            const testSplit = (100 - testTrainSplit) / 100;
+            const testCount = Math.ceil(testSplit * assetArray.length);
+
+            const assetMetadatas = assetArray.map((asset, i) =>
+                MockFactory.createTestAssetMetadata(asset,
+                    i < (assetArray.length - testCount) ?
+                        [MockFactory.createTestRegion("Region" + i, [tags[0].name])] :
+                        [MockFactory.createTestRegion("Region" + i, [tags[1].name])]));
+            const testAssetsNames = splitTestAsset(assetMetadatas, tags, testSplit);
+
+            const trainAssetsArray = assetMetadatas.filter((assetMetadata) =>
+                testAssetsNames.indexOf(assetMetadata.asset.name) < 0);
+            const testAssetsArray = assetMetadatas.filter((assetMetadata) =>
+                testAssetsNames.indexOf(assetMetadata.asset.name) >= 0);
+
+            const expectedTestCount = Math.ceil(testSplit * testCount) +
+                Math.ceil(testSplit * (assetArray.length - testCount));
+            expect(testAssetsNames).toHaveLength(expectedTestCount);
+            expect(trainAssetsArray.length + testAssetsArray.length).toEqual(assetMetadatas.length);
+            expect(testAssetsArray).toHaveLength(expectedTestCount);
+
+            expect(testAssetsArray.filter((assetMetadata) => assetMetadata.regions[0].tags[0] === tags[0].name).length)
+                .toBeGreaterThan(0);
+            expect(testAssetsArray.filter((assetMetadata) => assetMetadata.regions[0].tags[0] === tags[1].name).length)
+                .toBeGreaterThan(0);
+        }
+
+        it("Correctly generated files based on 50/50 test / train split", async () => {
+            await testTestTrainSplit(50);
+        });
+
+        it("Correctly generated files based on 60/40 test / train split", async () => {
+            await testTestTrainSplit(60);
+        });
+
+        it("Correctly generated files based on 80/20 test / train split", async () => {
+            await testTestTrainSplit(80);
+        });
+
+        it("Correctly generated files based on 90/10 test / train split", async () => {
+            await testTestTrainSplit(90);
+        });
+    });
+});

--- a/src/providers/export/testAssetsSplitHelper.ts
+++ b/src/providers/export/testAssetsSplitHelper.ts
@@ -6,26 +6,25 @@ import { IAssetMetadata, ITag } from "../../models/applicationState";
  * @param params Params containing substitution values
  */
 export function splitTestAsset(allAssets: IAssetMetadata[], tags: ITag[], testSplitRatio: number): string[] {
-    const testAssets: string[] = [];
+    if (testSplitRatio <= 0 || testSplitRatio > 1) { return []; }
 
-    if (testSplitRatio > 0 && testSplitRatio <= 1) {
-        const tagsAssetDict: { [index: string]: { assetList: Set<string> } } = {};
-        tags.forEach((tag) => tagsAssetDict[tag.name] = { assetList: new Set() });
-        allAssets.forEach((assetMetadata) => {
-            assetMetadata.regions.forEach((region) => {
-                region.tags.forEach((tagName) => {
-                    if (tagsAssetDict[tagName]) {
-                        tagsAssetDict[tagName].assetList.add(assetMetadata.asset.name);
-                    }
-                });
+    const testAssets: string[] = [];
+    const tagsAssetDict: { [index: string]: { assetList: Set<string> } } = {};
+    tags.forEach((tag) => tagsAssetDict[tag.name] = { assetList: new Set() });
+    allAssets.forEach((assetMetadata) => {
+        assetMetadata.regions.forEach((region) => {
+            region.tags.forEach((tagName) => {
+                if (tagsAssetDict[tagName]) {
+                    tagsAssetDict[tagName].assetList.add(assetMetadata.asset.name);
+                }
             });
         });
+    });
 
-        for (const tagKey of Object.keys(tagsAssetDict)) {
-            const assetList = tagsAssetDict[tagKey].assetList;
-            const testCount = Math.ceil(assetList.size * testSplitRatio);
-            testAssets.push(...Array.from(assetList).slice(0, testCount));
-        }
+    for (const tagKey of Object.keys(tagsAssetDict)) {
+        const assetList = tagsAssetDict[tagKey].assetList;
+        const testCount = Math.ceil(assetList.size * testSplitRatio);
+        testAssets.push(...Array.from(assetList).slice(0, testCount));
     }
     return testAssets;
 }

--- a/src/providers/export/testAssetsSplitHelper.ts
+++ b/src/providers/export/testAssetsSplitHelper.ts
@@ -1,0 +1,31 @@
+import { IAssetMetadata, ITag } from "../../models/applicationState";
+
+/**
+ * A helper function to split train and test assets
+ * @param template String containing variables
+ * @param params Params containing substitution values
+ */
+export function splitTestAsset(allAssets: IAssetMetadata[], tags: ITag[], testSplitRatio: number): string[] {
+    const testAssets: string[] = [];
+
+    if (testSplitRatio > 0 && testSplitRatio <= 1) {
+        const tagsAssetDict: { [index: string]: { assetList: Set<string> } } = {};
+        tags.forEach((tag) => tagsAssetDict[tag.name] = { assetList: new Set() });
+        allAssets.forEach((assetMetadata) => {
+            assetMetadata.regions.forEach((region) => {
+                region.tags.forEach((tagName) => {
+                    if (tagsAssetDict[tagName]) {
+                        tagsAssetDict[tagName].assetList.add(assetMetadata.asset.name);
+                    }
+                });
+            });
+        });
+
+        for (const tagKey of Object.keys(tagsAssetDict)) {
+            const assetList = tagsAssetDict[tagKey].assetList;
+            const testCount = Math.ceil(assetList.size * testSplitRatio);
+            testAssets.push(...Array.from(assetList).slice(0, testCount));
+        }
+    }
+    return testAssets;
+}


### PR DESCRIPTION
The test asset may not included all tags when export with test/train split option and uneven distribution of tags in current venison (2.1.0). Here is an example:

Image 1-8 are tagged with Tag-1.
Image 9-10 are tagged with Tag-2.
Export provider: PascalVOC
Asset State: Only tagged Assets
Test / Train Split is 80%.

Output
tag-1_val.txt
```
asset-9.jpg -1
asset-10.jpg -1
```
tag-2_val.txt
```
asset-9.jpg 1
asset-10.jpg 1
```

In current venison, there is no images of tag "Tag-1" in the text file "tag-1_val.txt" because the split method is based on the whole image set so only image 9 & 10 are put in test asset. The split method is changed to extract the test assets by each tag and combine them at the end. Image 7,8,10 will put in test asset after the change applied. 

Output
tag-1_val.txt
```
asset-7.jpg 1
asset-8.jpg 1
asset-10.jpg -1
```
tag-2_val.txt
```
asset-7.jpg -1
asset-8.jpg -1
asset-10.jpg 1
```
