### PR TITLE
fix: Use image/jpeg as MIME type for canvas.toBlob

### DIFF
--- a/src/common/htmlFileReader.ts
+++ b/src/common/htmlFileReader.ts
@@ -136,7 +136,7 @@ export default class HtmlFileReader {
                 canvas.width = video.videoWidth;
                 const ctx = canvas.getContext("2d");
                 ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-                canvas.toBlob(resolve);
+                canvas.toBlob(resolve, "image/jpeg", 1.0);
             };
             video.onerror = reject;
             if (refresh) {


### PR DESCRIPTION
Retargeted. See https://github.com/microsoft/VoTT/pull/801.

Closes https://github.com/microsoft/VoTT/pull/801.
Closes https://github.com/microsoft/VoTT/issues/838.