### PR TITLE
fix: Resolve UnhandledPromiseRejection in test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,6 +12,16 @@ import { ErrorHandler } from "./react/components/common/errorHandler/errorHandle
 describe("App Component", () => {
     const defaultState: IApplicationState = initialState;
     const store = createReduxStore(defaultState);
+    const electronMock = {
+        ipcRenderer: {
+            send: jest.fn(),
+            on: jest.fn(),
+        },
+    };
+
+    beforeAll(() => {
+        delete (window as any).require;
+    });
 
     function createComponent() {
         return mount(

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,3 +5,11 @@ import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 // Silence console.log and console.group statements in testing
 console.log = console.group = function() {};
+const electronMock = {
+    ipcRenderer: {
+        send: jest.fn(),
+        on: jest.fn(),
+    },
+};
+
+window.require = jest.fn(() => electronMock);


### PR DESCRIPTION
Create `window.require` function in tests that returns an electron object

Resolves #849 