### PR TITLE
fix: add an extra div to display filename properly

### DIFF
--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -114,13 +114,15 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                     {this.renderBadges(asset)}
                     <AssetPreview asset={asset} />
                 </div>
-                <div className="asset-item-metadata">
-                    <span className="asset-filename" title={asset.name}>{asset.name}</span>
-                    {asset.size &&
-                        <span>
-                            {asset.size.width} x {asset.size.height}
-                        </span>
-                    }
+                <div>
+                    <div className="asset-item-metadata">
+                        <span className="asset-filename" title={asset.name}>{asset.name}</span>
+                        {asset.size &&
+                            <span>
+                                {asset.size.width} x {asset.size.height}
+                            </span>
+                        }
+                    </div>
                 </div>
             </div>
         );


### PR DESCRIPTION
Fixes #866
Where filename is clipped in sidebar.