### PR TITLE
feat: move asset preview to horizontal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ VoTT helps facilitate an end-to-end machine learning pipeline:
 
 <!-- toc -->
 
+
 - [VoTT (Visual Object Tagging Tool)](#vott-visual-object-tagging-tool)
   - [Table of Contents](#table-of-contents)
   - [Getting Started](#getting-started)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7319,8 +7319,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "optional": true
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -7341,14 +7340,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "optional": true
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -7363,20 +7360,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "optional": true
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "optional": true
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "optional": true
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -7493,8 +7487,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "optional": true
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -7506,7 +7499,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -7521,7 +7513,6 @@
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -7529,14 +7520,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "optional": true
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
                     "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -7555,7 +7544,6 @@
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -7636,8 +7624,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "optional": true
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -7649,7 +7636,6 @@
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -7735,8 +7721,7 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                    "optional": true
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -7772,7 +7757,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -7792,7 +7776,6 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -7836,14 +7819,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "optional": true
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                    "optional": true
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
                 }
             }
         },
@@ -14828,7 +14809,7 @@
         "react-modal": {
             "version": "3.8.1",
             "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.8.1.tgz",
-            "integrity": "sha1-cwD5Sm+SouF5lN4L5sy2FzRGTJ4=",
+            "integrity": "sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==",
             "requires": {
                 "exenv": "^1.2.0",
                 "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "vott-react": "^0.2.10"
     },
     "scripts": {
-        "start": "nf start -p 3000",
+        "start": "nf start -p 3030",
         "compile": "tsc",
         "build": "react-scripts build",
         "webpack:dev": "webpack --config ./config/webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "vott-react": "^0.2.10"
     },
     "scripts": {
-        "start": "nf start -p 3030",
+        "start": "nf start -p 3000",
         "compile": "tsc",
         "build": "react-scripts build",
         "webpack:dev": "webpack --config ./config/webpack.dev.js",

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -8,7 +8,7 @@
   overflow: hidden;
   position: relative;
 
-  &-sidebar {
+  &-bottombar {
     display: flex;
     flex-grow: 1;
 

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -11,8 +11,10 @@
   &-bottombar {
     display: flex;
     flex-grow: 1;
+    flex-direction: row;
 
     &-nav {
+      height: 100%;
       width: 100%;
 
       .asset-list {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -187,22 +187,13 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         icon={"fa-lock"}
                         handler={this.handleCtrlTagHotKey} />);
                 })}
-                <SplitPane split="vertical"
-                    defaultSize={this.state.thumbnailSize.width}
+                <SplitPane split="horizontal"
                     minSize={100}
                     maxSize={400}
                     paneStyle={{ display: "flex" }}
                     onChange={this.onSideBarResize}
-                    onDragFinished={this.onSideBarResizeComplete}>
-                    <div className="editor-page-sidebar bg-lighter-1">
-                        <EditorSideBar
-                            assets={rootAssets}
-                            selectedAsset={selectedAsset ? selectedAsset.asset : null}
-                            onBeforeAssetSelected={this.onBeforeAssetSelected}
-                            onAssetSelected={this.selectAsset}
-                            thumbnailSize={this.state.thumbnailSize}
-                        />
-                    </div>
+                    onDragFinished={this.onSideBarResizeComplete}
+                    primary={"second"}>
                     <div className="editor-page-content" onClick={this.onPageClick}>
                         <div className="editor-page-content-main">
                             <div className="editor-page-content-main-header">
@@ -258,6 +249,15 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                             message={strings.editorPage.tags.delete.confirmation}
                             confirmButtonColor="danger"
                             onConfirm={this.onTagDeleted} />
+                    </div>
+                    <div className="editor-page-bottombar bg-lighter-1">
+                        <EditorSideBar
+                            assets={rootAssets}
+                            selectedAsset={selectedAsset ? selectedAsset.asset : null}
+                            onBeforeAssetSelected={this.onBeforeAssetSelected}
+                            onAssetSelected={this.selectAsset}
+                            thumbnailSize={this.state.thumbnailSize}
+                        />
                     </div>
                 </SplitPane>
                 <Alert show={this.state.showInvalidRegionWarning}

--- a/src/react/components/pages/editorPage/editorSideBar.test.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.test.tsx
@@ -129,4 +129,32 @@ describe("Editor SideBar", () => {
 
         expect(recomputeGridSizeSpy).toBeCalled();
     });
+
+    it("Correctly computes Grid column size", () => {
+        const props: IEditorSideBarProps = {
+            assets: testAssets,
+            onAssetSelected: onSelectAssetHandler,
+            thumbnailSize: {
+                width: 175,
+                height: 155,
+            },
+        };
+
+        const wrapper = createComponent(props);
+        const grid = wrapper.find(Grid).instance() as Grid;
+        const autoSizer = wrapper.find(AutoSizer).instance() as AutoSizer;
+        autoSizer.setState({
+            width: 150,
+            height: 91,
+        });
+
+        wrapper.setProps({
+            thumbnailSize: {
+                width: 150,
+                height: 91,
+            },
+        });
+
+        expect(grid.props.columnWidth()).toBe(100);
+    });
 });

--- a/src/react/components/pages/editorPage/editorSideBar.test.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.test.tsx
@@ -148,13 +148,6 @@ describe("Editor SideBar", () => {
             height: 91,
         });
 
-        wrapper.setProps({
-            thumbnailSize: {
-                width: 150,
-                height: 91,
-            },
-        });
-
         expect(grid.props.columnWidth()).toBe(100);
     });
 });

--- a/src/react/components/pages/editorPage/editorSideBar.test.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import EditorSideBar, { IEditorSideBarProps, IEditorSideBarState } from "./editorSideBar";
 import { ReactWrapper, mount } from "enzyme";
-import { AutoSizer, List } from "react-virtualized";
+import { AutoSizer, Grid } from "react-virtualized";
 import MockFactory from "../../../../common/mockFactory";
 
 describe("Editor SideBar", () => {
@@ -21,7 +21,7 @@ describe("Editor SideBar", () => {
         const wrapper = createComponent(props);
         expect(wrapper.exists()).toBe(true);
         expect(wrapper.find(AutoSizer).exists()).toBe(true);
-        expect(wrapper.find(List).exists()).toBe(true);
+        expect(wrapper.find(Grid).exists()).toBe(true);
     });
 
     it("Initializes state without asset selected", () => {
@@ -117,8 +117,8 @@ describe("Editor SideBar", () => {
         };
 
         const wrapper = createComponent(props);
-        const list = wrapper.find(List).instance() as List;
-        const recomputeRowHeightsSpy = jest.spyOn(list, "recomputeRowHeights");
+        const grid = wrapper.find(Grid).instance() as Grid;
+        const recomputeGridSizeSpy = jest.spyOn(grid, "recomputeGridSize");
 
         wrapper.setProps({
             thumbnailSize: {
@@ -127,6 +127,6 @@ describe("Editor SideBar", () => {
             },
         });
 
-        expect(recomputeRowHeightsSpy).toBeCalled();
+        expect(recomputeGridSizeSpy).toBeCalled();
     });
 });

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AutoSizer, List } from "react-virtualized";
+import { AutoSizer, Grid } from "react-virtualized";
 import { IAsset, AssetState, ISize } from "../../../../models/applicationState";
 import { AssetPreview } from "../../common/assetPreview/assetPreview";
 import { strings } from "../../../../common/strings";
@@ -38,23 +38,24 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
             : 0,
     };
 
-    private listRef: React.RefObject<List> = React.createRef();
+    private listRef: React.RefObject<Grid> = React.createRef();
 
     public render() {
         return (
             <div className="editor-page-sidebar-nav">
                 <AutoSizer>
                     {({ height, width }) => (
-                        <List
+                        <Grid
                             ref={this.listRef}
                             className="asset-list"
+                            cellRenderer={this.rowRenderer}
+                            columnCount={this.props.assets.length}
+                            columnWidth={() => this.getColumnWidth(height)}
                             height={height}
                             width={width}
-                            rowCount={this.props.assets.length}
-                            rowHeight={() => this.getRowHeight(width)}
+                            rowCount={1}
+                            rowHeight={height}
                             rowRenderer={this.rowRenderer}
-                            overscanRowCount={2}
-                            scrollToIndex={this.state.scrollToIndex}
                         />
                     )}
                 </AutoSizer>
@@ -64,7 +65,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
 
     public componentDidUpdate(prevProps: IEditorSideBarProps) {
         if (prevProps.thumbnailSize !== this.props.thumbnailSize) {
-            this.listRef.current.recomputeRowHeights();
+            this.listRef.current.recomputeGridSize();
         }
 
         if (!prevProps.selectedAsset && !this.props.selectedAsset) {
@@ -77,8 +78,8 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
         }
     }
 
-    private getRowHeight = (width: number) => {
-        return width / (4 / 3) + 16;
+    private getColumnWidth = (height: number) => {
+        return (height - 16) * (4 / 3);
     }
 
     private selectAsset = (selectedAsset: IAsset): void => {
@@ -87,7 +88,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
         this.setState({
             scrollToIndex,
         }, () => {
-            this.listRef.current.forceUpdateGrid();
+            this.listRef.current.forceUpdate();
         });
     }
 
@@ -102,8 +103,8 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
         this.props.onAssetSelected(asset);
     }
 
-    private rowRenderer = ({ key, index, style }): JSX.Element => {
-        const asset = this.props.assets[index];
+    private rowRenderer = ({ columnIndex, key, style }): JSX.Element => {
+        const asset = this.props.assets[columnIndex];
         const selectedAsset = this.props.selectedAsset;
 
         return (

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -42,7 +42,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
 
     public render() {
         return (
-            <div className="editor-page-sidebar-nav">
+            <div className="editor-page-bottombar-nav">
                 <AutoSizer>
                     {({ height, width }) => (
                         <Grid
@@ -80,7 +80,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
 
     private getColumnWidth = (height: number) => {
         const padding = 16;
-        const aspectRatio = 4 / 3;
+        const aspectRatio = (4 / 3);
 
         return (height - padding) * aspectRatio;
     }

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -79,7 +79,10 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     }
 
     private getColumnWidth = (height: number) => {
-        return (height - 16) * (4 / 3);
+        const padding = 16;
+        const aspectRatio = 4 / 3;
+
+        return (height - padding) * aspectRatio;
     }
 
     private selectAsset = (selectedAsset: IAsset): void => {


### PR DESCRIPTION
feat: change sidebar from vertical to horizontal

Moved the vertical asset previewer to be horizontal and at the bottom of the screen. This helps maximize the size of the picture being tagged when it is a landscape photo.

AB#860