### PR TITLE
feat: add preview of filepaths in project settings

### DIFF
--- a/src/react/components/common/connectionPicker/connectionPicker.tsx
+++ b/src/react/components/common/connectionPicker/connectionPicker.tsx
@@ -58,7 +58,7 @@ export class ConnectionPicker extends React.Component<IConnectionPickerProps, IC
                         <option
                             className="connection-option"
                             key={connection.id}
-                            value={connection.id}>{connection.name}
+                            value={connection.id}>{this.getConnectionText(connection)}
                         </option>)
                     }
                 </select>
@@ -69,6 +69,18 @@ export class ConnectionPicker extends React.Component<IConnectionPickerProps, IC
                 </div>
             </div>
         );
+    }
+
+    private getConnectionText = (connection: IConnection): string => {
+        const options = connection.providerOptions;
+
+        if (options["folderPath"]) {
+            return `${connection.name} (${options["folderPath"]})`;
+        } else if (options["accountName"]) {
+            return `${connection.name} (Azure:${options["accountName"]}\\${options["containerName"]})`;
+        } else {
+            return connection.name;
+        }
     }
 
     private onChange = (e) => {


### PR DESCRIPTION
Previously, in project settings, a user could only see the display name of the source and target connections, which might not have made clear which directory or storage account they were using. This adds the filepath or storageaccount and container name the to project settings dropdowns for source and target connection.

Resolves #792

Before:
![project-settings](https://user-images.githubusercontent.com/22548484/63625516-c1ef9580-c5b4-11e9-9654-09cda96c349b.PNG)
After:
![project-settings-filepath-preview](https://user-images.githubusercontent.com/22548484/63625535-ce73ee00-c5b4-11e9-8992-fafe97ed84ad.PNG)
