### PR TITLE
feat: Shortcut keys for Next/Previous Visited Frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ When the video playback bar is present, it allows the following shortcuts to sel
 * D or ArrowRight - Next Frame
 * Q - Previous Tagged Frame
 * E - Next Tagged Frame
+* H - Previous Visited Frame
+* L - Next Visited Frame
 
 #### Mouse Controls
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ When the video playback bar is present, it allows the following shortcuts to sel
 * H - Previous Visited Frame
 * L - Next Visited Frame
 
+( U - Make Current Frame Unvisited )
+
 #### Mouse Controls
 
 * Two-point mode - Hold down Ctrl while creating a region

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -241,6 +241,12 @@ export const english: IAppStrings = {
             nextTaggedFrame: {
                 tooltip: "Next Tagged Frame",
             },
+            previousVisitedFrame: {
+                tooltip: "Previous Visited Frame",
+            },
+            nextVisitedFrame: {
+                tooltip: "Next Visited Frame",
+            },
             previousExpectedFrame: {
                 tooltip: "Previous Frame",
             },

--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -253,6 +253,9 @@ export const english: IAppStrings = {
             nextExpectedFrame: {
                 tooltip: "Next Frame",
             },
+            makeCurrentFrameUnvisited: {
+                tooltip: "Make Current Frame Unvisited",
+            },
         },
         help: {
             title: "Toggle Help Menu",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -243,6 +243,12 @@ export const spanish: IAppStrings = {
             nextTaggedFrame: {
                 tooltip: "Siguiente marco etiquetado",
             },
+            previousVisitedFrame: {
+                tooltip: "Fotograma visitado anterior",
+            },
+            nextVisitedFrame: {
+                tooltip: "Siguiente marco visitado",
+            },
             previousExpectedFrame: {
                 tooltip: "Fotograma anterior",
             },

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -255,6 +255,9 @@ export const spanish: IAppStrings = {
             nextExpectedFrame: {
                 tooltip: "Siguiente marco",
             },
+            makeCurrentFrameUnvisited: {
+                tooltip: "Hacer que el marco actual no sea visitado",
+            },
         },
         help: {
             title: "Abrir/cerrar el menú de ayuda",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -246,6 +246,12 @@ export interface IAppStrings {
             previousExpectedFrame: {
                 tooltip: string,
             },
+            nextVisitedFrame: {
+                tooltip: string,
+            },
+            previousVisitedFrame: {
+                tooltip: string,
+            },
         }
         help: {
             title: string;

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -252,6 +252,9 @@ export interface IAppStrings {
             previousVisitedFrame: {
                 tooltip: string,
             },
+            makeCurrentFrameUnvisited: {
+                tooltip: string,
+            },
         }
         help: {
             title: string;

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -9,6 +9,7 @@ import { IAssetProps } from "./assetPreview";
 import { IAsset, AssetType, AssetState } from "../../../../models/applicationState";
 import { AssetService } from "../../../../services/assetService";
 import { CustomVideoPlayerButton } from "../../common/videoPlayer/customVideoPlayerButton";
+import { CustomVideoPlayerKeyBinding } from "../../common/videoPlayer/customVideoPlayerButton";
 import { strings } from "../../../../common/strings";
 
 /**
@@ -119,6 +120,20 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
                         >
                             <i className="fas fa-step-forward"></i>
                         </CustomVideoPlayerButton>
+                        <CustomVideoPlayerKeyBinding order={8.3}
+                            accelerators={["H", "h"]}
+                            tooltip={strings.editorPage.videoPlayer.previousVisitedFrame.tooltip}
+                            onClick={this.movePreviousVisitedFrame}
+                            icon={"fas fa-step-backward"}
+                        >
+                        </CustomVideoPlayerKeyBinding>
+                        <CustomVideoPlayerKeyBinding order={8.4}
+                            accelerators={["L", "l"]}
+                            tooltip={strings.editorPage.videoPlayer.nextVisitedFrame.tooltip}
+                            onClick={this.moveNextVisitedFrame}
+                            icon={"fas fa-step-forward"}
+                        >
+                        </CustomVideoPlayerKeyBinding>
                     </ControlBar>
                 }
             </Player >
@@ -171,6 +186,35 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
         const currentTime = this.getVideoPlayerState().currentTime;
         const nextFrame = this.props.childAssets
             .find((asset) => asset.state === AssetState.Tagged && asset.timestamp > currentTime);
+
+        if (nextFrame) {
+            this.seekToTime(nextFrame.timestamp);
+        }
+    }
+
+    /**
+     * Bound to the "Previous Visited Frame" button
+     * Seeks the user to the previous visited video frame
+     */
+    private movePreviousVisitedFrame = () => {
+        const currentTime = this.getVideoPlayerState().currentTime;
+        const previousFrame = _
+            .reverse(this.props.childAssets)
+            .find((asset) => asset.state === AssetState.Visited && asset.timestamp < currentTime);
+
+        if (previousFrame) {
+            this.seekToTime(previousFrame.timestamp);
+        }
+    }
+
+    /**
+     * Bound to the "Next Visited Frame" button
+     * Seeks the user to the next visited video frame
+     */
+    private moveNextVisitedFrame = () => {
+        const currentTime = this.getVideoPlayerState().currentTime;
+        const nextFrame = this.props.childAssets
+            .find((asset) => asset.state === AssetState.Visited && asset.timestamp > currentTime);
 
         if (nextFrame) {
             this.seekToTime(nextFrame.timestamp);

--- a/src/react/components/common/assetPreview/videoAsset.tsx
+++ b/src/react/components/common/assetPreview/videoAsset.tsx
@@ -134,6 +134,13 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
                             icon={"fas fa-step-forward"}
                         >
                         </CustomVideoPlayerKeyBinding>
+                        <CustomVideoPlayerKeyBinding order={8.5}
+                            accelerators={["U", "u"]}
+                            tooltip={strings.editorPage.videoPlayer.makeCurrentFrameUnvisited.tooltip}
+                            onClick={this.makeCurrentFrameUnvisited}
+                            icon={"fas fa-trash-alt"}
+                        >
+                        </CustomVideoPlayerKeyBinding>
                     </ControlBar>
                 }
             </Player >
@@ -161,6 +168,23 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
         if (this.props.timestamp !== prevProps.timestamp) {
             this.seekToTime(this.props.timestamp);
         }
+    }
+
+    /**
+     * Bound to the "Make Current Frame Unvisited" key binding
+     * Make current frame unvisited
+     */
+    private makeCurrentFrameUnvisited = () => {
+        const currentTime = this.getVideoPlayerState().currentTime;
+        const currentFrame:IAsset = this.props.childAssets
+            .find((asset) => asset.timestamp == currentTime);
+
+        if(currentFrame){
+            currentFrame.state = AssetState.NotVisited;
+        }
+
+        this.movePreviousTaggedFrame();
+        this.moveNextTaggedFrame();
     }
 
     /**
@@ -193,7 +217,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     }
 
     /**
-     * Bound to the "Previous Visited Frame" button
+     * Bound to the "Previous Visited Frame" key binding
      * Seeks the user to the previous visited video frame
      */
     private movePreviousVisitedFrame = () => {
@@ -208,7 +232,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
     }
 
     /**
-     * Bound to the "Next Visited Frame" button
+     * Bound to the "Next Visited Frame" key binding
      * Seeks the user to the next visited video frame
      */
     private moveNextVisitedFrame = () => {
@@ -418,7 +442,7 @@ export class VideoAsset extends React.Component<IVideoAssetProps> {
      * @param videoDuration The total video duration
      */
     private renderChildAssetMarker = (childAsset: IAsset, videoDuration: number) => {
-        const className = childAsset.state === AssetState.Tagged ? "video-timeline-tagged" : "video-timeline-visited";
+        const className = childAsset.state === AssetState.Tagged ? "video-timeline-tagged" : (childAsset.state === AssetState.Visited ? "video-timeline-visited": "video-timeline-notvisited");
         const childPosition: number = (childAsset.timestamp / videoDuration);
         const style = { left: `${childPosition * 100}%` };
 

--- a/src/react/components/common/videoPlayer/customVideoPlayerButton.tsx
+++ b/src/react/components/common/videoPlayer/customVideoPlayerButton.tsx
@@ -34,3 +34,19 @@ export class CustomVideoPlayerButton extends React.Component<ICustomVideoPlayerB
         );
     }
 }
+
+export class CustomVideoPlayerKeyBinding extends React.Component<ICustomVideoPlayerButtonProps> {
+    public render() {
+        return (
+            <Fragment>
+                {this.props.accelerators &&
+                    <KeyboardBinding keyEventType={KeyEventType.KeyDown}
+                        displayName={this.props.tooltip}
+                        accelerators={this.props.accelerators}
+                        handler={this.props.onClick}
+                        icon={this.props.icon}/>
+                }
+            </Fragment>
+        );
+    }
+}

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -188,7 +188,8 @@
 
   .video-timeline {
     &-tagged,
-    &-visited {
+    &-visited,
+    &-notvisited {
       width: 2px;
       position: absolute;
       height: 100%;
@@ -203,6 +204,11 @@
 
     &-visited {
       background-color: yellow;
+      z-index: 1;
+    }
+
+    &-notvisited {
+      background-color: #484848;
       z-index: 1;
     }
   }


### PR DESCRIPTION
Hello. I added new shortcut keys for Next/Previous Visited Frame (Issue #903)

- A or ArrowLeft - Previous Frame
- D or ArrowRight - Next Frame
- Q - Previous Tagged Frame
- E - Next Tagged Frame
- **H - Previous Visited Frame (<- Added)**
- **L - Next Visited Frame (<- Added)**