### PR TITLE
docs: reference external tools for converting labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ Click on the `Export` (arrow) icon in the left hand navigation. Select the appro
 
 ![alt text](docs/images/export-labels.jpg "Export Labels")
 
+### Converting Labels
+
+To convert the VoTT JSON schema to and from other formats (such as COCO JSON or YOLO TXT), you can use the following (unofficial) third-party tools:
+
+* [Pascal VOC to VoTT JSON](https://github.com/Chappie74/convert_pascalvoc_to_vott)
+* [From VoTT JSON to COCO JSON, YOLO TXT, and other formats](https://roboflow.com/formats/vott-json)
+
 ### Keyboard Shortcuts
 
 VoTT allows a number of keyboard shortcuts to make it easier to keep one hand on the mouse while tagging. It allows most common shortcuts:


### PR DESCRIPTION
Add links in the docs to external tools to convert the VoTT schema to and from other formats.

VoTT does not yet support exporting to other popular formats (eg YOLO TXT) or importing labels from other annotation tools. There have been been several issues requesting this additional functionality.

fix #994 #970 #913 #902 #803 #800 #292 #262 #151 #97