### PR TITLE
fix: Updates node-sass version to support local development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2229,9 +2229,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2246,7 +2246,7 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -8478,9 +8478,9 @@
             }
         },
         "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8689,9 +8689,9 @@
             }
         },
         "globule": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-            "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+            "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
             "dev": true,
             "requires": {
                 "glob": "~7.1.1",
@@ -9594,9 +9594,9 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "in-publish": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
             "dev": true
         },
         "indent-string": {
@@ -10938,9 +10938,9 @@
             "dev": true
         },
         "js-base64": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.0.tgz",
-            "integrity": "sha1-QiVboYOrZ85ZoN7mQK/cAKta6T4=",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
             "dev": true
         },
         "js-levenshtein": {
@@ -11303,22 +11303,10 @@
             "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
-        "lodash.assign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-            "dev": true
-        },
         "lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-        },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -11394,12 +11382,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-        },
-        "lodash.mergewith": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-            "dev": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -11991,7 +11973,8 @@
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-            "integrity": "sha1-exqhk+mqhgV+PHu9CsRI53CSVVI="
+            "integrity": "sha1-exqhk+mqhgV+PHu9CsRI53CSVVI=",
+            "optional": true
         },
         "nanoid": {
             "version": "2.0.0",
@@ -12219,9 +12202,9 @@
             }
         },
         "node-sass": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-            "integrity": "sha1-GD+uw5jpy+k7pDNi4naMqYimNpo=",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+            "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -12231,16 +12214,14 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
+                "lodash": "^4.17.15",
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
+                "nan": "^2.13.2",
                 "node-gyp": "^3.8.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
-                "sass-graph": "^2.2.4",
+                "sass-graph": "2.2.5",
                 "stdout-stream": "^1.4.0",
                 "true-case-path": "^1.0.2"
             },
@@ -12273,6 +12254,18 @@
                         "lru-cache": "^4.0.1",
                         "which": "^1.2.9"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+                    "dev": true
+                },
+                "nan": {
+                    "version": "2.14.2",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+                    "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "2.0.0",
@@ -17026,77 +17019,170 @@
             }
         },
         "sass-graph": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+            "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
             "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
                 "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
+                "yargs": "^13.3.2"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
                 "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
                 },
                 "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
                     }
                 },
-                "os-locale": {
-                    "version": "1.4.0",
-                    "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                    "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "lcid": "^1.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
-                "which-module": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                    "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
                     "dev": true
                 },
                 "yargs": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
                         "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
+                        "require-main-filename": "^2.0.0",
                         "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
                     }
                 },
                 "yargs-parser": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -17892,9 +17978,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -17909,7 +17995,7 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -18288,13 +18374,13 @@
             "integrity": "sha1-TSl5I8WnKkI2DeKrUtrfquwAAY4="
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
             "dev": true,
             "requires": {
                 "block-stream": "*",
-                "fstream": "^1.0.2",
+                "fstream": "^1.0.12",
                 "inherits": "2"
             }
         },

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "foreman": "^3.0.1",
         "jest-enzyme": "^7.0.1",
         "jquery": "^3.3.1",
-        "node-sass": "^4.10.0",
+        "node-sass": "^4.14.1",
         "popper.js": "^1.14.6",
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-logger": "^3.0.6",


### PR DESCRIPTION
The current version of node-sass is very outdated which is causing build errors due to 404 not found requests to components no longer available.

This PR updates to latest version of node sass and confirms local development can be setup.