### PR TITLE
Fix: Update custom vision url

### DIFF
--- a/src/providers/export/azureCustomVision.test.ts
+++ b/src/providers/export/azureCustomVision.test.ts
@@ -94,7 +94,7 @@ describe("Azure Custom Vision Export Provider", () => {
 
         expect(customVisionMock).toBeCalledWith({
             apiKey: providerOptions.apiKey,
-            baseUrl: `https://${providerOptions.region}.api.cognitive.microsoft.com/customvision/v2.2/Training`,
+            baseUrl: `https://${providerOptions.region}.api.cognitive.microsoft.com/customvision/v3.3/Training`,
         });
     });
 

--- a/src/providers/export/azureCustomVision.ts
+++ b/src/providers/export/azureCustomVision.ts
@@ -74,7 +74,7 @@ export class AzureCustomVisionProvider extends ExportProvider<IAzureCustomVision
 
         const cusomVisionServiceOptions: IAzureCustomVisionServiceOptions = {
             apiKey: options.apiKey,
-            baseUrl: `https://${options.region}.api.cognitive.microsoft.com/customvision/v2.2/Training`,
+            baseUrl: `https://${options.region}.api.cognitive.microsoft.com/customvision/v3.3/Training`,
         };
         this.customVisionService = new AzureCustomVisionService(cusomVisionServiceOptions);
     }

--- a/src/providers/export/azureCustomVision.ui.json
+++ b/src/providers/export/azureCustomVision.ui.json
@@ -9,7 +9,7 @@
         "ui:widget": "externalPicker",
         "ui:options": {
             "method": "GET",
-            "url": "https://${props.formContext.providerOptions.region}.api.cognitive.microsoft.com/customvision/v2.2/Training/projects",
+            "url": "https://${props.formContext.providerOptions.region}.api.cognitive.microsoft.com/customvision/v3.3/Training/projects",
             "authHeaderName": "Training-key",
             "authHeaderValue": "${props.formContext.providerOptions.apiKey}",
             "keySelector": "${item.id}",
@@ -20,7 +20,7 @@
         "ui:widget": "externalPicker",
         "ui:options": {
             "method": "GET",
-            "url": "https://${props.formContext.providerOptions.region}.api.cognitive.microsoft.com/customvision/v2.2/Training/domains",
+            "url": "https://${props.formContext.providerOptions.region}.api.cognitive.microsoft.com/customvision/v3.3/Training/domains",
             "authHeaderName": "Training-key",
             "authHeaderValue": "${props.formContext.providerOptions.apiKey}",
             "keySelector": "${item.id}",

--- a/src/providers/export/azureCustomVision/azureCustomVisionService.test.ts
+++ b/src/providers/export/azureCustomVision/azureCustomVisionService.test.ts
@@ -13,7 +13,7 @@ describe("Azure Custom Vision Service", () => {
 
     beforeEach(() => {
         customVisionOptions = {
-            baseUrl: "https://southcentralus.api.cognitive.microsoft.com/customvision/v2.2/Training",
+            baseUrl: "https://southcentralus.api.cognitive.microsoft.com/customvision/v3.3/Training",
             apiKey: "ABC123",
         };
         customVisionService = new AzureCustomVisionService(customVisionOptions);


### PR DESCRIPTION
Azure Custom Vision REST API endpoint was updated and the old one was deprecated. Updating to current version