### PR TITLE
fix: Adds missing registration of mixins to support 'forEachAsync'

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -2,6 +2,7 @@ import {
     app, ipcMain, BrowserWindow, BrowserWindowConstructorOptions,
     Menu, MenuItemConstructorOptions,
 } from "electron";
+import registerMixins from "../registerMixins";
 import { IpcMainProxy } from "./common/ipcMainProxy";
 import LocalFileSystem from "./providers/storage/localFileSystem";
 
@@ -123,6 +124,8 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
     const menu = Menu.buildFromTemplate(menuItems);
     Menu.setApplicationMenu(menu);
 }
+
+registerMixins();
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.

--- a/src/electron/providers/storage/localFileSystem.ts
+++ b/src/electron/providers/storage/localFileSystem.ts
@@ -95,7 +95,6 @@ export default class LocalFileSystem implements IStorageProvider {
 
     public async listFiles(folderPath: string): Promise<string[]> {
         const normalizedPath = path.normalize(folderPath);
-        console.log(`Listing files from ${normalizedPath}`);
         const files = await this.listItems(normalizedPath, (stats) => !stats.isDirectory());
         const directories = await this.listItems(normalizedPath, (stats) => stats.isDirectory());
         await directories.forEachAsync(async (directory) => {


### PR DESCRIPTION
The electron main process did not register the mixins which was causing recursive file system calls to fail.

- [x] Registers mixin @ electron main
- [x] Removes console.log statement 